### PR TITLE
Extract Various ScriptModules Into Own Folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,8 @@
+{
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "es5",
+  "bracketSpacing": true
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,11 @@
+import { EffectManager } from "./modules/effect-manager";
+import { EventManager } from "./modules/event-manager";
+import { FrontendCommunicator } from "./modules/frontend-communicator";
+import { TwitchChat } from "./modules/twitch-chat";
+import { Logger } from "./modules/logger";
+import { ReplaceVariableManager } from "./modules/replace-variable-manager";
+import { EventFilterManager } from "./modules/event-filter-manager";
+
 type BaseParameter = {
   description?: string;
   secondaryDescription?: string;
@@ -102,55 +110,14 @@ type Trigger = {
   };
 };
 
-interface LeveledLogMethod {
-  (msg: string, ...meta: any[]): void;
-}
-
 type ScriptModules = {
-  effectManager: {
-    registerEffect: <EffectModel>(
-      effectType: Firebot.EffectType<EffectModel>
-    ) => void;
-  };
-  eventManager: {
-    registerEventSource: (eventSource: Firebot.EventSource) => void;
-    triggerEvent: (
-      sourceId: string,
-      eventId: string,
-      meta: Record<string, unknown>,
-      isManual?: boolean
-    ) => void;
-  };
-  frontendCommunicator: {
-    send(eventName: string, data: unknown): void;
-    on<ExpectedArgs extends Array<any> = [], ReturnPayload = void>(
-      eventName: string,
-      callback: (...args: ExpectedArgs[]) => ReturnPayload
-    ): void;
-    onAsync<ExpectedArgs extends Array<any> = [], ReturnPayload = void>(
-      eventName: string,
-      callback: (...args: ExpectedArgs[]) => Promise<ReturnPayload>
-    ): void;
-  };
-  twitchChat: {
-    sendChatMessage(
-      message: string,
-      whisperTarget?: string,
-      accountType?: "bot" | "streamer"
-    ): void;
-  };
-  logger: {
-    debug: LeveledLogMethod;
-    info: LeveledLogMethod;
-    warn: LeveledLogMethod;
-    error: LeveledLogMethod;
-  };
-  replaceVariableManager: {
-    registerReplaceVariable(replaceVariable: Firebot.ReplaceVariable): void;
-  };
-  eventFilterManager: {
-    registerFilter(filter: Firebot.EventFilter): void;
-  };
+  effectManager: EffectManager;
+  eventManager: EventManager;
+  frontendCommunicator: FrontendCommunicator;
+  twitchChat: TwitchChat;
+  logger: Logger;
+  replaceVariableManager: ReplaceVariableManager;
+  eventFilterManager: EventFilterManager;
 };
 
 type RunRequest<P extends Record<string, any>> = {
@@ -224,54 +191,6 @@ export namespace Firebot {
     ): void | ScriptReturnObject | Promise<ScriptReturnObject>;
   };
 
-  type EventSource = {
-    id: string;
-    name: string;
-    events: Array<{
-      id: string;
-      name: string;
-      description: string;
-      cached?: boolean;
-      manualMetadata?: Record<string, unknown>;
-    }>;
-  };
-
-  type ReplaceVariable = {
-    definition: {
-      handle: string;
-      usage?: string;
-      description: string;
-      examples?: Array<{
-        usage: string;
-        description: string;
-      }>;
-      triggers?: TriggersObject;
-      possibleDataOutput: Array<"text" | "number">;
-    };
-    evaluator(trigger: Trigger, ...args: any[]): any;
-  };
-
-  type EventFilter = {
-    id: string;
-    name: string;
-    description: string;
-    events: Array<{
-      eventSourceId: string;
-      eventId: string;
-    }>;
-    comparisonTypes: string[];
-    valueType: "text" | "preset";
-    presetValues(...args: any[]): Promise<any[]>;
-    predicate(
-      filterSettings: { comparisonType: string; value: any },
-      eventData: {
-        eventSourceId: string;
-        eventId: string;
-        eventMeta: Record<string, any>;
-      }
-    ): Promise<boolean>;
-  };
-
   type EffectType<EffectModel> = {
     definition: {
       id: string;
@@ -323,5 +242,6 @@ export namespace Firebot {
     | "firebot:sequentialeffect"
     | "firebot:set-user-metadata"
     | "firebot:showImage"
-    | "firebot:showtext";
+    | "firebot:showtext"
+    | "firebot:update-counter";
 }

--- a/modules/effect-manager.d.ts
+++ b/modules/effect-manager.d.ts
@@ -1,0 +1,7 @@
+import { Firebot } from "../index";
+
+export type EffectManager = {
+  registerEffect: <EffectModel>(
+    effectType: Firebot.EffectType<EffectModel>
+  ) => void;
+};

--- a/modules/event-filter-manager.d.ts
+++ b/modules/event-filter-manager.d.ts
@@ -1,0 +1,24 @@
+type EventFilter = {
+  id: string;
+  name: string;
+  description: string;
+  events: Array<{
+    eventSourceId: string;
+    eventId: string;
+  }>;
+  comparisonTypes: string[];
+  valueType: "text" | "preset";
+  presetValues(...args: any[]): Promise<any[]>;
+  predicate(
+    filterSettings: { comparisonType: string; value: any },
+    eventData: {
+      eventSourceId: string;
+      eventId: string;
+      eventMeta: Record<string, any>;
+    }
+  ): Promise<boolean>;
+};
+
+export type EventFilterManager = {
+  registerFilter(filter: EventFilter): void;
+};

--- a/modules/event-manager.d.ts
+++ b/modules/event-manager.d.ts
@@ -1,0 +1,21 @@
+type EventSource = {
+  id: string;
+  name: string;
+  events: Array<{
+    id: string;
+    name: string;
+    description: string;
+    cached?: boolean;
+    manualMetadata?: Record<string, unknown>;
+  }>;
+};
+
+export type EventManager = {
+  registerEventSource: (eventSource: EventSource) => void;
+  triggerEvent: (
+    sourceId: string,
+    eventId: string,
+    meta: Record<string, unknown>,
+    isManual?: boolean
+  ) => void;
+};

--- a/modules/frontend-communicator.d.ts
+++ b/modules/frontend-communicator.d.ts
@@ -1,0 +1,11 @@
+export type FrontendCommunicator = {
+  send(eventName: string, data: unknown): void;
+  on<ExpectedArgs extends Array<any> = [], ReturnPayload = void>(
+    eventName: string,
+    callback: (...args: ExpectedArgs[]) => ReturnPayload
+  ): void;
+  onAsync<ExpectedArgs extends Array<any> = [], ReturnPayload = void>(
+    eventName: string,
+    callback: (...args: ExpectedArgs[]) => Promise<ReturnPayload>
+  ): void;
+};

--- a/modules/logger.d.ts
+++ b/modules/logger.d.ts
@@ -1,0 +1,10 @@
+interface LeveledLogMethod {
+  (msg: string, ...meta: any[]): void;
+}
+
+export type Logger = {
+  debug: LeveledLogMethod;
+  info: LeveledLogMethod;
+  warn: LeveledLogMethod;
+  error: LeveledLogMethod;
+};

--- a/modules/replace-variable-manager.d.ts
+++ b/modules/replace-variable-manager.d.ts
@@ -1,0 +1,20 @@
+import { Trigger, TriggersObject } from "../index";
+
+type ReplaceVariable = {
+  definition: {
+    handle: string;
+    usage?: string;
+    description: string;
+    examples?: Array<{
+      usage: string;
+      description: string;
+    }>;
+    triggers?: TriggersObject;
+    possibleDataOutput: Array<"text" | "number">;
+  };
+  evaluator(trigger: Trigger, ...args: any[]): any;
+};
+
+export type ReplaceVariableManager = {
+  registerReplaceVariable(replaceVariable: ReplaceVariable): void;
+};

--- a/modules/twitch-chat.d.ts
+++ b/modules/twitch-chat.d.ts
@@ -1,0 +1,7 @@
+export type TwitchChat = {
+  sendChatMessage(
+    message: string,
+    whisperTarget?: string,
+    accountType?: "bot" | "streamer"
+  ): void;
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,35 @@
+{
+  "name": "firebot-custom-scripts-types",
+  "version": "5.27.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "version": "5.27.0",
+      "license": "ISC",
+      "devDependencies": {
+        "prettier": "2.2.1"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
+      "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    }
+  },
+  "dependencies": {
+    "prettier": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
+      "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -3,9 +3,15 @@
   "version": "5.27.0",
   "description": "Types for Firebot's Custom Scripts",
   "main": "",
-  "scripts": {},
+  "scripts": {
+    "prettier:check": "prettier --check '**/*.{json,ts}'",
+    "prettier:format": "prettier --write '**/*.{json,ts}'"
+  },
   "author": "ebiggz",
   "license": "ISC",
   "types": "index.d.ts",
-  "typeScriptVersion": "4.0.2"
+  "typeScriptVersion": "4.0.2",
+  "devDependencies": {
+    "prettier": "2.2.1"
+  }
 }


### PR DESCRIPTION
This refactors the various modules part of `ScriptModules` each into their own file as a starting point to not have all type declarations in a single file.
Therefore, it does not yet add the additional modules that are present in `backend/common/handlers/custom-scripts/custom-script-helpers.js`.

Additionally, it adds a `prettier` config to achieve a consistent style.