### PR TITLE
Modules: Counter- and Quotes-Manager

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,6 +5,8 @@ import { TwitchChat } from "./modules/twitch-chat";
 import { Logger } from "./modules/logger";
 import { ReplaceVariableManager } from "./modules/replace-variable-manager";
 import { EventFilterManager } from "./modules/event-filter-manager";
+import { CounterManager } from "./modules/counter-manager";
+import { QuotesManager } from "./modules/quotes-manager";
 
 type BaseParameter = {
   description?: string;
@@ -118,6 +120,8 @@ type ScriptModules = {
   logger: Logger;
   replaceVariableManager: ReplaceVariableManager;
   eventFilterManager: EventFilterManager;
+  counterManager: CounterManager;
+  quotesManager: QuotesManager;
 };
 
 type RunRequest<P extends Record<string, any>> = {

--- a/modules/counter-manager.d.ts
+++ b/modules/counter-manager.d.ts
@@ -1,0 +1,41 @@
+import { Effect } from "../index";
+
+type Counter = {
+  id: string;
+  name: string;
+  value: number;
+  saveToTxtFile: boolean;
+  /**
+   * Effects that are triggered when the counter value has reached its maximal value.
+   */
+  maximumEffects: { id: string; list: Effect[] };
+  /**
+   * Effects that are triggered when the counter value has reached its minimal value.
+   */
+  minimumEffects: { id: string; list: Effect[] };
+  /**
+   * Effects that are triggered when the counter value is updated.
+   */
+  updateEffects: { id: string; list: Effect[] };
+};
+
+export type CounterManager = {
+  createCounter: (name: string) => Counter;
+  getCounter: (id: string) => Counter | undefined;
+  /**
+   * Finds a counter with the given name.
+   * @param name the human-readable name of the counter.
+   */
+  getCounterByName: (name: string) => Counter | undefined;
+  /**
+   * Changes the value of the counter by/to value.
+   * @param id of the counter that should be changed.
+   * @param value the counter should be changed by/to. Can be negative.
+   * @param overridePreviousValue if true: sets the counter to `value`; if false: adds `value` to the counter.
+   */
+  updateCounterValue: (
+    id: string,
+    value: number,
+    overridePreviousValue: boolean
+  ) => Promise<void>;
+};

--- a/modules/event-filter-manager.d.ts
+++ b/modules/event-filter-manager.d.ts
@@ -1,4 +1,4 @@
-type EventFilter = {
+export type EventFilter = {
   id: string;
   name: string;
   description: string;

--- a/modules/event-manager.d.ts
+++ b/modules/event-manager.d.ts
@@ -1,4 +1,4 @@
-type EventSource = {
+export type EventSource = {
   id: string;
   name: string;
   events: Array<{

--- a/modules/quotes-manager.d.ts
+++ b/modules/quotes-manager.d.ts
@@ -1,0 +1,49 @@
+type Quote = {
+  readonly _id: number;
+  createdAt: Date;
+  creator: string;
+  originator: string;
+  text: string;
+  game: string | undefined;
+};
+
+type DateConfig = {
+  day: number;
+  month: number;
+  year: number;
+};
+
+export type QuotesManager = {
+  /**
+   * Creates a new quote, returning the `_id` it was saved with.
+   * @param quote the quote to add. Ignores the `_id` and uses a new unique one.
+   */
+  addQuote: (quote: Quote) => Promise<number>;
+  /**
+   * Updates the given quote and returns it.
+   * @param quote the one to update.
+   * @param dontSendUiUpdateEvent if true, does not trigger a UI update on change; default: false
+   */
+  updateQuote: (quote: Quote, dontSendUiUpdateEvent?: boolean) => Promise<Quote>;
+  /**
+   * Removes the given quote from the database.
+   * @param quoteId of the quote to remove.
+   * @param dontSendUiUpdateEvent if true, does not trigger a UI update; default: false
+   */
+  removeQuote: (quoteId: number, dontSendUiUpdateEvent?: boolean) => Promise<void>;
+  getQuote: (id: number) => Promise<Quote | undefined>;
+  getRandomQuoteByDate: (date: DateConfig) => Promise<Quote | undefined>;
+  getRandomQuoteByAuthor: (author: string) => Promise<Quote | undefined>;
+  /**
+   * Returns a random quote which game matches the regex pattern case-insensitively.
+   * @param pattern the quote’s game should match.
+   */
+  getRandomQuoteByGame: (pattern: string) => Promise<Quote | undefined>;
+  /**
+   * Returns a random quote which contains text that matches the regex pattern.
+   * @param pattern the quote’s text should contain.
+   */
+  getRandomQuoteContainingText: (pattern: string) => Promise<Quote | undefined>;
+  getRandomQuote: () => Promise<Quote | undefined>;
+  getAllQuotes: () => Promise<Quote[] | undefined>;
+};

--- a/modules/replace-variable-manager.d.ts
+++ b/modules/replace-variable-manager.d.ts
@@ -1,6 +1,6 @@
 import { Trigger, TriggersObject } from "../index";
 
-type ReplaceVariable = {
+export type ReplaceVariable = {
   definition: {
     handle: string;
     usage?: string;


### PR DESCRIPTION
Part of #2: This adds the counter and quotes managers to the `ScriptModules`.

Additionally, the existing types `EventFilter`, `EventSource`, and `ReplaceVariable` are exported, as script creators might want to create own classes that implement those. This is only possible if they are exported.