### PR TITLE
Add: Game Manager Module

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -14,6 +14,7 @@ import { QuotesManager } from "./modules/quotes-manager";
 import { Effects } from "./effects";
 import { TwitchApi } from "./modules/twitch-api";
 import { Utils } from "./modules/utils";
+import { GameManager } from "./modules/game-manager";
 
 type BaseParameter = {
   description?: string;
@@ -93,6 +94,7 @@ type ScriptModules = {
   effectManager: EffectManager;
   eventManager: EventManager;
   frontendCommunicator: FrontendCommunicator;
+  gameManager: GameManager;
   twitchApi: TwitchApi;
   twitchChat: TwitchChat;
   logger: Logger;

--- a/types/modules/counter-manager.d.ts
+++ b/types/modules/counter-manager.d.ts
@@ -1,4 +1,5 @@
-import { Effect, EffectList } from "../effects";
+import { Effects } from "../effects";
+import EffectList = Effects.EffectList;
 
 type Counter = {
   id: string;

--- a/types/modules/effect-manager.d.ts
+++ b/types/modules/effect-manager.d.ts
@@ -1,4 +1,5 @@
-import { EffectType } from "../effects";
+import { Effects } from "../effects";
+import EffectType = Effects.EffectType;
 
 export type EffectManager = {
   registerEffect: <EffectModel>(

--- a/types/modules/game-manager.d.ts
+++ b/types/modules/game-manager.d.ts
@@ -1,0 +1,101 @@
+type SettingType =
+  | "string"
+  | "number"
+  | "boolean"
+  | "enum"
+  | "filepath"
+  | "currency-select"
+  | "chatter-select"
+  | "editable-list"
+  | "role-percentages"
+  | "role-numbers";
+
+export type SettingDefinition = {
+  type: SettingType;
+  title: string;
+  description: string;
+  /**
+   * Human readable tip, this is rendered below the field in smaller muted text.
+   */
+  tip: string;
+  default: any;
+  /**
+   * A rank to tell the UI how to order settings.
+   */
+  sortRank: number;
+  /*
+   * Display a line under the setting.
+   */
+  showBottomHr: boolean;
+  validation: {
+    required: boolean;
+    /**
+     * Only needed if the `type` is `number`.
+     */
+    min?: number;
+    /**
+     * Only needed if the `type` is `number`.
+     */
+    max?: number;
+  };
+};
+
+/**
+ * A setting category which holds a dictionary of settings.
+ */
+export type SettingCategoryDefinition = {
+  title: string;
+  description: string;
+  sortRank: number;
+  settings: Record<string, SettingDefinition>;
+};
+
+export type GameSettings = {
+  active: boolean;
+  /**
+   * Dictionary of dictionaries that contains game settings saved by the user.
+   * Outer index: category; inner: setting in that category.
+   */
+  settings: Record<string, Record<string, any>>;
+};
+
+type GameFn = (gameSettings: GameSettings) => void;
+
+export type FirebotGame = {
+  /**
+   * Must be unique among all games registered in the Firebot system.
+   */
+  id: string;
+  name: string;
+  subtitle: string;
+  description: string;
+  /**
+   * Font Awesome 5 icon to use for the game, ie `fa-dice-three`.
+   */
+  icon: string;
+  settingCategories: Record<string, SettingCategoryDefinition>;
+  /**
+   * Called when the game is enabled, either on app load or if the user enables the game later.
+   * You can register a system command here or set up any required game state.
+   */
+  onLoad: GameFn;
+  /**
+   * Called when the game was previously active but has since been disabled.
+   * You should unregister any system commands here and clear out any game state.
+   */
+  onUnload: GameFn;
+  /**
+   * Called whenever the settings from `settingCategories` are updated by the user.
+   */
+  onSettingsUpdate: GameFn;
+};
+
+export type GameManager = {
+  /**
+   * Registers a game in the Firebot system.
+   *
+   * Does not register the game if its `id` already exists in the Firebot system.
+   * @param game that should be registered.
+   */
+  registerGame: (game: FirebotGame) => void;
+};

--- a/types/modules/replace-variable-manager.d.ts
+++ b/types/modules/replace-variable-manager.d.ts
@@ -1,4 +1,6 @@
-import { Trigger, TriggersObject } from "../effects";
+import { Effects } from "../effects";
+import TriggersObject = Effects.TriggersObject;
+import Trigger = Effects.Trigger;
 
 export type ReplaceVariable = {
   definition: {


### PR DESCRIPTION
Part of #2. The `game-manager.js` already contained the type informations, so I just had to translate them into Typescript definitions.

Also fixes some more issues with the changed `Effects` imports.