### PR TITLE
Add CommandManager Module

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,23 +1,24 @@
 import * as FsExtra from "fs-extra";
 import * as Path from "path";
+import { CommandManager } from "./modules/command-manager";
+import { CounterManager } from "./modules/counter-manager";
 import { CurrencyDB } from "./modules/currency-db"
 import { CurrencyManager } from "./modules/currency-manager";
 import { CustomVariableManager } from "./modules/custom-variable-manager";
 import { EffectManager } from "./modules/effect-manager";
-import { EventManager } from "./modules/event-manager";
-import { FrontendCommunicator } from "./modules/frontend-communicator";
-import { FirebotRolesManager } from "./modules/firebot-roles-manager";
-import { TwitchChat } from "./modules/twitch-chat";
-import { Logger } from "./modules/logger";
-import { ReplaceVariableManager } from "./modules/replace-variable-manager";
-import { EventFilterManager } from "./modules/event-filter-manager";
-import { UserDb } from "./modules/user-db";
-import { CounterManager } from "./modules/counter-manager";
-import { QuotesManager } from "./modules/quotes-manager";
 import { Effects } from "./effects";
-import { TwitchApi } from "./modules/twitch-api";
-import { Utils } from "./modules/utils";
+import { EventFilterManager } from "./modules/event-filter-manager";
+import { EventManager } from "./modules/event-manager";
+import { FirebotRolesManager } from "./modules/firebot-roles-manager";
+import { FrontendCommunicator } from "./modules/frontend-communicator";
 import { GameManager } from "./modules/game-manager";
+import { Logger } from "./modules/logger";
+import { QuotesManager } from "./modules/quotes-manager";
+import { ReplaceVariableManager } from "./modules/replace-variable-manager";
+import { TwitchApi } from "./modules/twitch-api";
+import { TwitchChat } from "./modules/twitch-chat";
+import { UserDb } from "./modules/user-db";
+import { Utils } from "./modules/utils";
 
 type BaseParameter = {
   description?: string;
@@ -93,25 +94,26 @@ type CustomScriptManifest = {
 };
 
 type ScriptModules = {
+  commandManager: CommandManager;
+  counterManager: CounterManager;
   currencyDb: CurrencyDB;
   currencyManager: CurrencyManager;
+  customVariableManager: CustomVariableManager;
   effectManager: EffectManager;
+  eventFilterManager: EventFilterManager;
   eventManager: EventManager;
+  firebotRolesManager: FirebotRolesManager;
   frontendCommunicator: FrontendCommunicator;
+  fs: typeof FsExtra;
   gameManager: GameManager;
+  logger: Logger;
+  path: typeof Path;
+  quotesManager: QuotesManager;
+  replaceVariableManager: ReplaceVariableManager;
   twitchApi: TwitchApi;
   twitchChat: TwitchChat;
-  logger: Logger;
-  customVariableManager: CustomVariableManager;
-  replaceVariableManager: ReplaceVariableManager;
-  eventFilterManager: EventFilterManager;
   userDb: UserDb;
-  firebotRolesManager: FirebotRolesManager;
-  counterManager: CounterManager;
-  quotesManager: QuotesManager;
   utils: Utils;
-  path: typeof Path;
-  fs: typeof FsExtra;
   /** Remove the below line after we have all modules defined */
   [x: string]: unknown;
 };

--- a/types/modules/command-manager.d.ts
+++ b/types/modules/command-manager.d.ts
@@ -1,0 +1,113 @@
+import { Effects } from "../effects";
+import EffectList = Effects.EffectList;
+
+type CommandType = "system" | "custom";
+
+type Cooldown = {
+  /**
+   * Global cooldown to use a command in seconds.
+   */
+  global: number | undefined;
+  /**
+   * Cooldown for each user to use a command in seconds.
+   */
+  user: number | undefined;
+};
+
+type RestrictionData = {
+  /**
+   * Sets the command to only trigger when all/any/none of the restrictions pass.
+   */
+  mode: "all" | "any" | "none";
+  /**
+   * If a chat message should be sent when the restrictions are not met.
+   */
+  sendFailMessage: boolean;
+  restrictions: any[]; // ToDo: change when restriction-manager and companion types are added
+};
+
+export type SubCommand = {
+  id: string;
+  active: boolean;
+  type: CommandType;
+  arg: string;
+  regex: boolean;
+  fallback: boolean;
+  restrictionData: RestrictionData;
+  effects: EffectList;
+};
+
+export type CommandDefinition = {
+  id: string;
+  type: CommandType;
+  createdBy: string;
+  createdAt: Date;
+  lastEditBy: string | undefined;
+  lastEditAt: Date | undefined;
+  /**
+   * Describes how many times the command has been used in chat.
+   */
+  count: number;
+  active: boolean;
+  trigger: string;
+  triggerIsRegex: boolean | undefined;
+  scanWholeMessage: boolean | undefined;
+  /**
+   * If the chat message that triggered the command should be deleted automatically.
+   */
+  autoDeleteTrigger: boolean | undefined;
+  /**
+   * If the UI should show the edit page in simple or advanced mode.
+   */
+  simple: boolean;
+  /**
+   * If the command should be hidden from the `!commands` list.
+   */
+  hidden: boolean | undefined;
+  ignoreBot: boolean | undefined;
+  ignoreStreamer: boolean | undefined;
+  /**
+   * If a chat message should be sent when the command is tried to be used but
+   * the cooldown is not yet over.
+   */
+  sendCooldownMessage: boolean;
+  baseCommandDescription: string | undefined;
+  sortTags: string[];
+  cooldown: Cooldown | undefined;
+  effects: EffectList;
+  restrictionData: RestrictionData;
+  options: Record<string, any>;
+  subCommands: SubCommand[] | undefined;
+  fallbackSubcommand: SubCommand | undefined;
+};
+
+export type Command = {
+  definition: CommandDefinition;
+  active: boolean;
+  trigger: string;
+};
+
+type CommandManager = {
+  getAllActiveCommands: () => Command[];
+  triggerIsTaken: (trigger: string) => boolean;
+
+  registerSystemCommand: (command: Command) => void;
+  unregisterSystemCommand: (id: string) => void;
+  getSystemCommandById: (id: string) => Command | undefined;
+  getSystemCommands: () => Command[];
+  getSystemCommandTrigger: (id: string) => string | undefined;
+  getAllSystemCommandDefinitions: () => CommandDefinition[];
+  hasSystemCommand: (id: string) => boolean;
+
+  getCustomCommandById: (id: string) => Command | undefined;
+  getAllCustomCommands: () => Command[];
+  /**
+   * Creates a new custom command or updates an existing one.
+   * @param command the command to create/update.
+   * @param user the user making the change.
+   * @param isNew if the command is a new one or if an existing one should be updated.
+   *              Default: true.
+   */
+  saveCustomCommand: (command: Command, user: string, isNew?: boolean) => void;
+  removeCustomCommandByTrigger: (trigger: string) => void;
+};


### PR DESCRIPTION
Part of #2.

I pieced together the `CommandDefinition` type from saved commands in `chat/commands.json` in the profile directory. You should check that no fields are missing, or that existing ones are marked as `T` when they should be `T | undefined`.
I could not find where/how the `CommandDefinition.options` field is used besides [here in `CommandManager`](https://github.com/crowbartools/Firebot/blob/1e6c6d8158c5d721797a7f132d150ec969d5bb11/backend/chat/commands/CommandManager.js#L94) and therefore just assumed a type of `Record<string, any>`.

In `index.ts` most of the changes are due to reordering the imports and `ScriptModules` to be in alphabetic order.