### PR TITLE
feat: add PromiseLike<void> run return type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -185,7 +185,7 @@ export namespace Firebot {
     getDefaultParameters(): DefaultParametersConfig<P>;
     run(
       runRequest: RunRequest<P>
-    ): void | ScriptReturnObject | Promise<ScriptReturnObject>;
+    ): void | PromiseLike<void> | ScriptReturnObject | Promise<ScriptReturnObject>;
   };
 
   type EffectType<EffectModel> = Effects.EffectType<EffectModel>;


### PR DESCRIPTION
Adds the `PromiseLike<void>` return type to the script `run()` function