### PR TITLE
Type fixes and additions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "conventionalCommits.scopes": [
-        "Remove active and trigger from Command type since it is already required in the CommandDefinition"
-    ]
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "conventionalCommits.scopes": [
+        "Remove active and trigger from Command type since it is already required in the CommandDefinition"
+    ]
+}

--- a/types/modules/command-manager.d.ts
+++ b/types/modules/command-manager.d.ts
@@ -83,8 +83,6 @@ export type CommandDefinition = {
 
 export type Command = {
   definition: CommandDefinition;
-  active: boolean;
-  trigger: string;
 };
 
 type CommandManager = {

--- a/types/modules/command-manager.d.ts
+++ b/types/modules/command-manager.d.ts
@@ -78,7 +78,7 @@ export type CommandDefinition = {
   cooldown: Cooldown | undefined;
   effects: EffectList;
   restrictionData: RestrictionData;
-  options: Record<string, any>;
+  options: Record<string, any> | undefined;
   subCommands: SubCommand[] | undefined;
   fallbackSubcommand: SubCommand | undefined;
 };

--- a/types/modules/command-manager.d.ts
+++ b/types/modules/command-manager.d.ts
@@ -23,6 +23,7 @@ type RestrictionData = {
    * If a chat message should be sent when the restrictions are not met.
    */
   sendFailMessage: boolean;
+  failMessage: string;
   restrictions: any[]; // ToDo: change when restriction-manager and companion types are added
 };
 

--- a/types/modules/command-manager.d.ts
+++ b/types/modules/command-manager.d.ts
@@ -39,6 +39,7 @@ export type SubCommand = {
 
 export type CommandDefinition = {
   id: string;
+  name: string;
   type: CommandType;
   createdBy: string;
   createdAt: Date;

--- a/types/modules/command-manager.d.ts
+++ b/types/modules/command-manager.d.ts
@@ -40,6 +40,7 @@ export type SubCommand = {
 export type CommandDefinition = {
   id: string;
   name: string;
+  description: string;
   type: CommandType;
   createdBy: string;
   createdAt: Date;


### PR DESCRIPTION
Changes:
- Remove active and trigger properties from Command type. (They are in CommandDefinition already.)
- Add name property to CommandDefinition type.
- Add description property to CommandDefinition type.
- Add undefined to property Options for CommandDefinitition. (Allows you to hide the blank settings area on the command.)
- Add failMessage property to RestrictionData type.

One thing I'm running into even with this update:
- Register a new system command with both description and baseCommandDescription filled out, but the description still does not show in firebot.