### PR TITLE
Add getEffectById to EffectManager 

### DIFF
--- a/types/modules/effect-manager.d.ts
+++ b/types/modules/effect-manager.d.ts
@@ -2,6 +2,6 @@ import { Effects } from "../effects";
 import EffectType = Effects.EffectType;
 
 export type EffectManager = {
-    getEffectById: (effectId: string) => EffectType<unknown> | undefined;
+    getEffectById: <EffectModel>(effectId: string) => EffectType<EffectModel> | undefined;
     registerEffect: <EffectModel>(effectType: EffectType<EffectModel>) => void;
 };

--- a/types/modules/effect-manager.d.ts
+++ b/types/modules/effect-manager.d.ts
@@ -2,5 +2,6 @@ import { Effects } from "../effects";
 import EffectType = Effects.EffectType;
 
 export type EffectManager = {
+    getEffectById: (effectId: string) => EffectType<unknown> | undefined;
     registerEffect: <EffectModel>(effectType: EffectType<EffectModel>) => void;
 };


### PR DESCRIPTION
Trivial addition of `getEffectById` function to `EffectManager` to allow third-party scripts to directly execute effects.

This addresses issue #25.