### PR TITLE
Add UserDb.createNewUser, fix FirebotUser attribute types

### DIFF
--- a/types/modules/user-db.d.ts
+++ b/types/modules/user-db.d.ts
@@ -27,12 +27,10 @@ type FirebotUser = {
 };
 
 export type UserDb = {
-    getTwitchUserByUsername: (
-        username: string
-    ) => Promise<FirebotUser | null>;
+    getTwitchUserByUsername: (username: string) => Promise<FirebotUser | null>;
     /**
      * Creates a new user in the database. Returns the created user if successful.
-     * 
+     *
      * @param userId User's Twitch account ID
      * @param username Twitch username
      * @param displayName Twitch display name
@@ -46,7 +44,8 @@ export type UserDb = {
         displayName: string,
         profilePicUrl?: string,
         twitchRoles?: string[],
-        isOnline?: boolean) => Promise<FirebotUser | null>;
+        isOnline?: boolean
+    ) => Promise<FirebotUser | null>;
     /**
      * Updates the given user in the database. Returns true if successful.
      * @param user that should be updated.

--- a/types/modules/user-db.d.ts
+++ b/types/modules/user-db.d.ts
@@ -1,14 +1,17 @@
 type FirebotUser = {
-    readonly _id: number;
+    readonly _id: string;
     username: string;
     displayName: string;
     profilePicUrl: string;
     twitch: boolean;
     twitchRoles: string[];
     online: boolean;
-    onlineAt: Date;
-    lastSeen: Date;
-    joinDate: Date;
+    /** Timestamp value */
+    onlineAt: number;
+    /** Timestamp value */
+    lastSeen: number;
+    /** Timestamp value */
+    joinDate: number;
     minutesInChannel: number;
     chatMessages: number;
     disableAutoStatAccrual: boolean;
@@ -26,7 +29,24 @@ type FirebotUser = {
 export type UserDb = {
     getTwitchUserByUsername: (
         username: string
-    ) => Promise<FirebotUser | undefined>;
+    ) => Promise<FirebotUser | null>;
+    /**
+     * Creates a new user in the database. Returns the created user if successful.
+     * 
+     * @param userId User's Twitch account ID
+     * @param username Twitch username
+     * @param displayName Twitch display name
+     * @param profilePicUrl Profile pic URL, if available
+     * @param twitchRoles List of role strings, if applicable
+     * @param isOnline Whether the user is currently online, defaults to false
+     */
+    createNewUser: (
+        userId: string,
+        username: string,
+        displayName: string,
+        profilePicUrl?: string,
+        twitchRoles?: string[],
+        isOnline?: boolean) => Promise<FirebotUser | null>;
     /**
      * Updates the given user in the database. Returns true if successful.
      * @param user that should be updated.


### PR DESCRIPTION
- Adds TypeScript interface for UserDb.createNewUser a.k.a. ViewerDatabase.createNewViewer
- FirebotUser._id is now a string.
- FirebotUser.onlineAt, FirebotUser.lastSeen, and FirebotUser.joinDate are raw timestamp values rather than Date objects.