### PR TITLE
Techdebt: Added missing property `aliases?` to `ReplaceVariable` type

### DIFF
--- a/types/modules/replace-variable-manager.d.ts
+++ b/types/modules/replace-variable-manager.d.ts
@@ -5,6 +5,7 @@ import Trigger = Effects.Trigger;
 export type ReplaceVariable = {
     definition: {
         handle: string;
+        aliases?: string[];
         usage?: string;
         description: string;
         examples?: Array<{


### PR DESCRIPTION
`aliases` was added to the `ReplaceVariable` object a little while back, but using it in scripts results in a ts2353 error because it's missing from the definition here. Just tossing up a quick PR to fix this.