### PR TITLE
Add firebot:cooldown-command to KnownEffectType

### DIFF
--- a/types/effects.d.ts
+++ b/types/effects.d.ts
@@ -77,7 +77,8 @@ export namespace Effects {
         | "firebot:set-user-metadata"
         | "firebot:showImage"
         | "firebot:showtext"
-        | "firebot:update-counter";
+        | "firebot:update-counter"
+        | "firebot:cooldown-command";
 
     type Effect<T = KnownEffectType> = {
         id?: string;


### PR DESCRIPTION
- Adds `firebot:cooldown-command` to `KnownEffectType`

I wanted to add an effect that would cancel a cooldown on a command under certain circumstances, but this was not exposed as a known event type. I confirmed that the following effect correctly canceled the global cooldown:

```js
{
  type: 'firebot:cooldown-command',
  selectionType: 'command',
  commandId: runRequest.trigger.metadata.command.id,
  action: 'Clear',
  clearUserCooldown: false,
  clearGlobalCooldown: true,
},
```