### PR TITLE
feat/fix: effects TriggerTypes, Missing ng Ref

### DIFF
--- a/types/effects.d.ts
+++ b/types/effects.d.ts
@@ -1,3 +1,5 @@
+import ng from "angular";
+
 interface EffectScope<EffectModel> extends ng.IScope {
     effect: EffectModel;
     [x: string]: unknown;
@@ -20,16 +22,18 @@ type EffectTriggerResponse<Outputs = Record<string, unknown>> = {
 
 export namespace Effects {
     type TriggerType =
-        | "command"
-        | "custom_script"
-        | "startup_script"
         | "api"
+        | "channel_reward"
+        | "command"
+        | "counter"
+        | "custom_script"
         | "event"
         | "hotkey"
-        | "timer"
-        | "counter"
         | "preset"
         | "quick_action"
+        | "scheduled_task"
+        | "startup_script"
+        | "timer"
         | "manual";
 
     type Trigger = {


### PR DESCRIPTION
- Alphabetize effect TriggerTypes, add missing options:
  - 'channel_reward'
  - 'scheduled_task'
- Add missing reference to angular as ng for EffectScope