### PR TITLE
Bump for v5.64.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,44 +1,41 @@
 {
     "name": "@crowbartools/firebot-custom-scripts-types",
-    "version": "5.63.1",
+    "version": "5.64.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@crowbartools/firebot-custom-scripts-types",
-            "version": "5.63.1",
+            "version": "5.64.0",
             "license": "ISC",
             "dependencies": {
-                "@twurple/api": "^7.0.6",
-                "@twurple/auth": "^7.0.6",
-                "@types/angular": "^1.8.1",
-                "@types/express": "^4.17.1",
-                "@types/node": "^18.18.2",
-                "moment": "^2.24.0"
+                "@twurple/api": "^7.2.1",
+                "@twurple/auth": "^7.2.1",
+                "@types/angular": "^1.8.4",
+                "@types/express": "^4.17.21",
+                "@types/node": "^20.17.12",
+                "moment": "^2.24.0",
+                "tiny-typed-emitter": "^2.1.0"
             },
             "devDependencies": {
                 "prettier": "2.2.1"
             }
         },
         "node_modules/@d-fischer/cache-decorators": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@d-fischer/cache-decorators/-/cache-decorators-3.0.0.tgz",
-            "integrity": "sha512-mYUCjrp5hJgimceC5bof3zzmElyxzW4ty+73IjY12wvxLAqsq0CbgLGspnJm6KgwEfGoeRnISZD4EXJidG3FvA==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@d-fischer/cache-decorators/-/cache-decorators-4.0.1.tgz",
+            "integrity": "sha512-HNYLBLWs/t28GFZZeqdIBqq8f37mqDIFO6xNPof94VjpKvuP6ROqCZGafx88dk5zZUlBfViV9jD8iNNlXfc4CA==",
+            "license": "MIT",
             "dependencies": {
-                "@d-fischer/shared-utils": "^3.0.1",
-                "@types/node": "^14.14.22",
-                "tslib": "^2.1.0"
+                "@d-fischer/shared-utils": "^3.6.3",
+                "tslib": "^2.6.2"
             }
         },
-        "node_modules/@d-fischer/cache-decorators/node_modules/@types/node": {
-            "version": "14.18.18",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.18.tgz",
-            "integrity": "sha512-B9EoJFjhqcQ9OmQrNorItO+OwEOORNn3S31WuiHvZY/dm9ajkB7AKD/8toessEtHHNL+58jofbq7hMMY9v4yig=="
-        },
         "node_modules/@d-fischer/cross-fetch": {
-            "version": "5.0.4",
-            "resolved": "https://registry.npmjs.org/@d-fischer/cross-fetch/-/cross-fetch-5.0.4.tgz",
-            "integrity": "sha512-u2IBCipsiE8565AbepyOrIk2LGuaIMr5ARFHHYmGmY9dp2HfX2iMqiLjPz0DnxH3ZBalYA4IxzxcstcgLIWRag==",
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/@d-fischer/cross-fetch/-/cross-fetch-5.0.5.tgz",
+            "integrity": "sha512-symjDUPInTrkfIsZc2n2mo9hiAJLcTJsZkNICjZajEWnWpJ3s3zn50/FY8xpNUAf5w3eFuQii2wxztTGpvG1Xg==",
+            "license": "MIT",
             "dependencies": {
                 "node-fetch": "^2.6.12"
             }
@@ -46,12 +43,14 @@
         "node_modules/@d-fischer/detect-node": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/@d-fischer/detect-node/-/detect-node-3.0.1.tgz",
-            "integrity": "sha512-0Rf3XwTzuTh8+oPZW9SfxTIiL+26RRJ0BRPwj5oVjZFyFKmsj9RGfN2zuTRjOuA3FCK/jYm06HOhwNK+8Pfv8w=="
+            "integrity": "sha512-0Rf3XwTzuTh8+oPZW9SfxTIiL+26RRJ0BRPwj5oVjZFyFKmsj9RGfN2zuTRjOuA3FCK/jYm06HOhwNK+8Pfv8w==",
+            "license": "MIT"
         },
         "node_modules/@d-fischer/logger": {
             "version": "4.2.3",
             "resolved": "https://registry.npmjs.org/@d-fischer/logger/-/logger-4.2.3.tgz",
             "integrity": "sha512-mJUx9OgjrNVLQa4od/+bqnmD164VTCKnK5B4WOW8TX5y/3w2i58p+PMRE45gUuFjk2BVtOZUg55JQM3d619fdw==",
+            "license": "MIT",
             "dependencies": {
                 "@d-fischer/detect-node": "^3.0.1",
                 "@d-fischer/shared-utils": "^3.2.0",
@@ -61,29 +60,11 @@
                 "url": "https://github.com/sponsors/d-fischer"
             }
         },
-        "node_modules/@d-fischer/promise.allsettled": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/@d-fischer/promise.allsettled/-/promise.allsettled-2.0.2.tgz",
-            "integrity": "sha512-xY0vYDwJYFe22MS5ccQ50N4Mcc2nQ8J4eWE5Y354IxZwW32O5uTT6mmhFSuVF6ZrKvzHOCIrK+9WqOR6TI3tcA==",
-            "dependencies": {
-                "array.prototype.map": "^1.0.3",
-                "call-bind": "^1.0.2",
-                "define-properties": "^1.1.3",
-                "es-abstract": "^1.18.0-next.2",
-                "get-intrinsic": "^1.0.2",
-                "iterate-value": "^1.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/d-fischer"
-            }
-        },
         "node_modules/@d-fischer/qs": {
             "version": "7.0.2",
             "resolved": "https://registry.npmjs.org/@d-fischer/qs/-/qs-7.0.2.tgz",
             "integrity": "sha512-yAu3xDooiL+ef84Jo8nLjDjWBRk7RXk163Y6aTvRB7FauYd3spQD/dWvgT7R4CrN54Juhrrc3dMY7mc+jZGurQ==",
+            "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.6"
             },
@@ -92,20 +73,24 @@
             }
         },
         "node_modules/@d-fischer/rate-limiter": {
-            "version": "0.7.5",
-            "resolved": "https://registry.npmjs.org/@d-fischer/rate-limiter/-/rate-limiter-0.7.5.tgz",
-            "integrity": "sha512-Waclzcv7dpCHVbXsvrSxfsLI1q3bGjmisaxHxHu5OzepQH/gAtxP7aAqTM5Jr+yssq6UM0u0NTAXComCgfu00w==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@d-fischer/rate-limiter/-/rate-limiter-1.0.1.tgz",
+            "integrity": "sha512-Mq+0pAJsx92hP83cjmsrXQZVQJ+/+u1JFT6fjH8pj3yfUrbT3eDBsA+6J63eat+QaC+Mci78HdiBfpsdBkdwog==",
+            "license": "MIT",
             "dependencies": {
-                "@d-fischer/logger": "^4.2.1",
-                "@d-fischer/promise.allsettled": "^2.0.2",
-                "@d-fischer/shared-utils": "^3.2.0",
-                "tslib": "^2.0.3"
+                "@d-fischer/logger": "^4.2.3",
+                "@d-fischer/shared-utils": "^3.6.3",
+                "tslib": "^2.6.2"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/d-fischer"
             }
         },
         "node_modules/@d-fischer/shared-utils": {
-            "version": "3.6.3",
-            "resolved": "https://registry.npmjs.org/@d-fischer/shared-utils/-/shared-utils-3.6.3.tgz",
-            "integrity": "sha512-Lz+Qk1WJLVoeREOHPZcIDTHOoxecxMSG2sq+x1xWYCH1exqiMKMMx06pXdy15UzHG7ohvQRNXk2oHqZ9EOl9jQ==",
+            "version": "3.6.4",
+            "resolved": "https://registry.npmjs.org/@d-fischer/shared-utils/-/shared-utils-3.6.4.tgz",
+            "integrity": "sha512-BPkVLHfn2Lbyo/ENDBwtEB8JVQ+9OzkjJhUunLaxkw4k59YFlQxUUwlDBejVSFcpQT0t+D3CQlX+ySZnQj0wxw==",
+            "license": "MIT",
             "dependencies": {
                 "tslib": "^2.4.1"
             },
@@ -117,6 +102,7 @@
             "version": "3.3.3",
             "resolved": "https://registry.npmjs.org/@d-fischer/typed-event-emitter/-/typed-event-emitter-3.3.3.tgz",
             "integrity": "sha512-OvSEOa8icfdWDqcRtjSEZtgJTFOFNgTjje7zaL0+nAtu2/kZtRCSK5wUMrI/aXtCH8o0Qz2vA8UqkhWUTARFQQ==",
+            "license": "MIT",
             "dependencies": {
                 "tslib": "^2.4.0"
             },
@@ -125,19 +111,20 @@
             }
         },
         "node_modules/@twurple/api": {
-            "version": "7.0.6",
-            "resolved": "https://registry.npmjs.org/@twurple/api/-/api-7.0.6.tgz",
-            "integrity": "sha512-Fe8haADUI+m4juCuNxtkWBX2HkCU6FA2+2Biq2/KRTp50FVRCeOBdDQpkdM4r+T2KE0NaiTpiH2rtaRodkR/gQ==",
+            "version": "7.2.1",
+            "resolved": "https://registry.npmjs.org/@twurple/api/-/api-7.2.1.tgz",
+            "integrity": "sha512-fqoX87GyHRL4pSmgloF5Mfj2XDJMx8fWBbcl4JGG7bgF2jvH5X9p3nzH169zqwSU/etfUdfytyoQ7/r2R+G3cg==",
+            "license": "MIT",
             "dependencies": {
-                "@d-fischer/cache-decorators": "^3.0.0",
+                "@d-fischer/cache-decorators": "^4.0.0",
                 "@d-fischer/cross-fetch": "^5.0.1",
                 "@d-fischer/detect-node": "^3.0.1",
                 "@d-fischer/logger": "^4.2.1",
-                "@d-fischer/rate-limiter": "^0.7.2",
+                "@d-fischer/rate-limiter": "^1.0.0",
                 "@d-fischer/shared-utils": "^3.6.1",
                 "@d-fischer/typed-event-emitter": "^3.3.1",
-                "@twurple/api-call": "7.0.6",
-                "@twurple/common": "7.0.6",
+                "@twurple/api-call": "7.2.1",
+                "@twurple/common": "7.2.1",
                 "retry": "^0.13.1",
                 "tslib": "^2.0.3"
             },
@@ -145,18 +132,19 @@
                 "url": "https://github.com/sponsors/d-fischer"
             },
             "peerDependencies": {
-                "@twurple/auth": "7.0.6"
+                "@twurple/auth": "7.2.1"
             }
         },
         "node_modules/@twurple/api-call": {
-            "version": "7.0.6",
-            "resolved": "https://registry.npmjs.org/@twurple/api-call/-/api-call-7.0.6.tgz",
-            "integrity": "sha512-3E9IAJRyRLji9bjmZzicWv/wP9aGVdIDkzaX4WaK3sTRC9EkZ3nWIxSj0WmJ977O2lDsUkpgxzwmskuDqdaTrQ==",
+            "version": "7.2.1",
+            "resolved": "https://registry.npmjs.org/@twurple/api-call/-/api-call-7.2.1.tgz",
+            "integrity": "sha512-x+p6fMleFA/pJHVu8tFpkDkARGGt30EAUA+cLc+dEtU1EpH1mv7nv5LLHh9NW9vdZpYp0jk5TyY/TSbHdj7Ggw==",
+            "license": "MIT",
             "dependencies": {
                 "@d-fischer/cross-fetch": "^5.0.1",
                 "@d-fischer/qs": "^7.0.2",
                 "@d-fischer/shared-utils": "^3.6.1",
-                "@twurple/common": "7.0.6",
+                "@twurple/common": "7.2.1",
                 "tslib": "^2.0.3"
             },
             "funding": {
@@ -164,15 +152,16 @@
             }
         },
         "node_modules/@twurple/auth": {
-            "version": "7.0.6",
-            "resolved": "https://registry.npmjs.org/@twurple/auth/-/auth-7.0.6.tgz",
-            "integrity": "sha512-kgjSdLRW9NKk9LD8dySkgjXDxzJQFAiNIBZFbQNgTqSn7A2ZwaxmapIxy7FcHyGV0MdRtimScnRbKK9Nm089Xw==",
+            "version": "7.2.1",
+            "resolved": "https://registry.npmjs.org/@twurple/auth/-/auth-7.2.1.tgz",
+            "integrity": "sha512-IGHsJ/g0RblRSBC59XKA9277rE5w1dAKdhCPQz1QwkWnt6fsUyVoD1ut+qZvjuh7ssX1SBtNzFqohydfmWZytg==",
+            "license": "MIT",
             "dependencies": {
                 "@d-fischer/logger": "^4.2.1",
                 "@d-fischer/shared-utils": "^3.6.1",
                 "@d-fischer/typed-event-emitter": "^3.3.1",
-                "@twurple/api-call": "7.0.6",
-                "@twurple/common": "7.0.6",
+                "@twurple/api-call": "7.2.1",
+                "@twurple/common": "7.2.1",
                 "tslib": "^2.0.3"
             },
             "funding": {
@@ -180,9 +169,10 @@
             }
         },
         "node_modules/@twurple/common": {
-            "version": "7.0.6",
-            "resolved": "https://registry.npmjs.org/@twurple/common/-/common-7.0.6.tgz",
-            "integrity": "sha512-38cufsx5k1ruUNrorXsiyTVBnFCXPFgr+MMkpMoFnh3T5G9drT3RkmE6Ss7oeaK6Glr/ihQNIPL6NzTJkGmXhA==",
+            "version": "7.2.1",
+            "resolved": "https://registry.npmjs.org/@twurple/common/-/common-7.2.1.tgz",
+            "integrity": "sha512-veLY5laA00dPuekAcpHN6GDvnr6s1uH7yBDebLC1NhpcLkQgiAlGA50RdNS5YeA3xz7kfE2MOcYSi2S6Qoc7EA==",
+            "license": "MIT",
             "dependencies": {
                 "@d-fischer/shared-utils": "^3.6.1",
                 "klona": "^2.0.4",
@@ -193,9 +183,10 @@
             }
         },
         "node_modules/@types/angular": {
-            "version": "1.8.1",
-            "resolved": "https://registry.npmjs.org/@types/angular/-/angular-1.8.1.tgz",
-            "integrity": "sha512-8zEjTC3gpkva6/dbUkiSxIUGUxYm9HD/pJJ0lbqfEM2TWqi/3vs4VtgoFxVXt5bmuJ+6G2caO2HaMD+NzB1VwA=="
+            "version": "1.8.4",
+            "resolved": "https://registry.npmjs.org/@types/angular/-/angular-1.8.4.tgz",
+            "integrity": "sha512-wPS/ncJWhyxJsndsW1B6Ta8D4mi97x1yItSu+rkLDytU3oRIh2CFAjMuJceYwFAh9+DIohndWM0QBA9OU2Hv0g==",
+            "license": "MIT"
         },
         "node_modules/@types/body-parser": {
             "version": "1.19.2",
@@ -215,23 +206,27 @@
             }
         },
         "node_modules/@types/express": {
-            "version": "4.17.1",
-            "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.1.tgz",
-            "integrity": "sha512-VfH/XCP0QbQk5B5puLqTLEeFgR8lfCJHZJKkInZ9mkYd+u8byX0kztXEQxEk4wZXJs8HI+7km2ALXjn4YKcX9w==",
+            "version": "4.17.21",
+            "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
+            "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
+            "license": "MIT",
             "dependencies": {
                 "@types/body-parser": "*",
-                "@types/express-serve-static-core": "*",
+                "@types/express-serve-static-core": "^4.17.33",
+                "@types/qs": "*",
                 "@types/serve-static": "*"
             }
         },
         "node_modules/@types/express-serve-static-core": {
-            "version": "4.17.28",
-            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz",
-            "integrity": "sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==",
+            "version": "4.19.6",
+            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.6.tgz",
+            "integrity": "sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==",
+            "license": "MIT",
             "dependencies": {
                 "@types/node": "*",
                 "@types/qs": "*",
-                "@types/range-parser": "*"
+                "@types/range-parser": "*",
+                "@types/send": "*"
             }
         },
         "node_modules/@types/mime": {
@@ -240,19 +235,35 @@
             "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw=="
         },
         "node_modules/@types/node": {
-            "version": "18.18.2",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.2.tgz",
-            "integrity": "sha512-u1cis+7wLZMPI62EozwsqvgMZyauczyiqRRu/vcqZKI5N5yidrJHqOFxEg5seT8adc96Q6Yczg1c0DlqGtMJMw=="
+            "version": "20.17.12",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.12.tgz",
+            "integrity": "sha512-vo/wmBgMIiEA23A/knMfn/cf37VnuF52nZh5ZoW0GWt4e4sxNquibrMRJ7UQsA06+MBx9r/H1jsI9grYjQCQlw==",
+            "license": "MIT",
+            "dependencies": {
+                "undici-types": "~6.19.2"
+            }
         },
         "node_modules/@types/qs": {
-            "version": "6.9.7",
-            "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
-            "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw=="
+            "version": "6.9.18",
+            "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.18.tgz",
+            "integrity": "sha512-kK7dgTYDyGqS+e2Q4aK9X3D7q234CIZ1Bv0q/7Z5IwRDoADNU81xXJK/YVyLbLTZCoIwUoDoffFeF+p/eIklAA==",
+            "license": "MIT"
         },
         "node_modules/@types/range-parser": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
-            "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+            "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+            "license": "MIT"
+        },
+        "node_modules/@types/send": {
+            "version": "0.17.4",
+            "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
+            "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/mime": "^1",
+                "@types/node": "*"
+            }
         },
         "node_modules/@types/serve-static": {
             "version": "1.13.10",
@@ -263,616 +274,11 @@
                 "@types/node": "*"
             }
         },
-        "node_modules/array-buffer-byte-length": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.0.tgz",
-            "integrity": "sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==",
-            "dependencies": {
-                "call-bind": "^1.0.2",
-                "is-array-buffer": "^3.0.1"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/array.prototype.map": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/array.prototype.map/-/array.prototype.map-1.0.6.tgz",
-            "integrity": "sha512-nK1psgF2cXqP3wSyCSq0Hc7zwNq3sfljQqaG27r/7a7ooNUnn5nGq6yYWyks9jMO5EoFQ0ax80hSg6oXSRNXaw==",
-            "dependencies": {
-                "call-bind": "^1.0.2",
-                "define-properties": "^1.2.0",
-                "es-abstract": "^1.22.1",
-                "es-array-method-boxes-properly": "^1.0.0",
-                "is-string": "^1.0.7"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/arraybuffer.prototype.slice": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.2.tgz",
-            "integrity": "sha512-yMBKppFur/fbHu9/6USUe03bZ4knMYiwFBcyiaXB8Go0qNehwX6inYPzK9U0NeQvGxKthcmHcaR8P5MStSRBAw==",
-            "dependencies": {
-                "array-buffer-byte-length": "^1.0.0",
-                "call-bind": "^1.0.2",
-                "define-properties": "^1.2.0",
-                "es-abstract": "^1.22.1",
-                "get-intrinsic": "^1.2.1",
-                "is-array-buffer": "^3.0.2",
-                "is-shared-array-buffer": "^1.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/available-typed-arrays": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
-            "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/call-bind": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.5.tgz",
-            "integrity": "sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==",
-            "dependencies": {
-                "function-bind": "^1.1.2",
-                "get-intrinsic": "^1.2.1",
-                "set-function-length": "^1.1.1"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/define-data-property": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.1.tgz",
-            "integrity": "sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==",
-            "dependencies": {
-                "get-intrinsic": "^1.2.1",
-                "gopd": "^1.0.1",
-                "has-property-descriptors": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/define-properties": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
-            "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-            "dependencies": {
-                "define-data-property": "^1.0.1",
-                "has-property-descriptors": "^1.0.0",
-                "object-keys": "^1.1.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/es-abstract": {
-            "version": "1.22.3",
-            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.22.3.tgz",
-            "integrity": "sha512-eiiY8HQeYfYH2Con2berK+To6GrK2RxbPawDkGq4UiCQQfZHb6wX9qQqkbpPqaxQFcl8d9QzZqo0tGE0VcrdwA==",
-            "dependencies": {
-                "array-buffer-byte-length": "^1.0.0",
-                "arraybuffer.prototype.slice": "^1.0.2",
-                "available-typed-arrays": "^1.0.5",
-                "call-bind": "^1.0.5",
-                "es-set-tostringtag": "^2.0.1",
-                "es-to-primitive": "^1.2.1",
-                "function.prototype.name": "^1.1.6",
-                "get-intrinsic": "^1.2.2",
-                "get-symbol-description": "^1.0.0",
-                "globalthis": "^1.0.3",
-                "gopd": "^1.0.1",
-                "has-property-descriptors": "^1.0.0",
-                "has-proto": "^1.0.1",
-                "has-symbols": "^1.0.3",
-                "hasown": "^2.0.0",
-                "internal-slot": "^1.0.5",
-                "is-array-buffer": "^3.0.2",
-                "is-callable": "^1.2.7",
-                "is-negative-zero": "^2.0.2",
-                "is-regex": "^1.1.4",
-                "is-shared-array-buffer": "^1.0.2",
-                "is-string": "^1.0.7",
-                "is-typed-array": "^1.1.12",
-                "is-weakref": "^1.0.2",
-                "object-inspect": "^1.13.1",
-                "object-keys": "^1.1.1",
-                "object.assign": "^4.1.4",
-                "regexp.prototype.flags": "^1.5.1",
-                "safe-array-concat": "^1.0.1",
-                "safe-regex-test": "^1.0.0",
-                "string.prototype.trim": "^1.2.8",
-                "string.prototype.trimend": "^1.0.7",
-                "string.prototype.trimstart": "^1.0.7",
-                "typed-array-buffer": "^1.0.0",
-                "typed-array-byte-length": "^1.0.0",
-                "typed-array-byte-offset": "^1.0.0",
-                "typed-array-length": "^1.0.4",
-                "unbox-primitive": "^1.0.2",
-                "which-typed-array": "^1.1.13"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/es-array-method-boxes-properly": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
-            "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA=="
-        },
-        "node_modules/es-get-iterator": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
-            "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
-            "dependencies": {
-                "call-bind": "^1.0.2",
-                "get-intrinsic": "^1.1.3",
-                "has-symbols": "^1.0.3",
-                "is-arguments": "^1.1.1",
-                "is-map": "^2.0.2",
-                "is-set": "^2.0.2",
-                "is-string": "^1.0.7",
-                "isarray": "^2.0.5",
-                "stop-iteration-iterator": "^1.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/es-set-tostringtag": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.2.tgz",
-            "integrity": "sha512-BuDyupZt65P9D2D2vA/zqcI3G5xRsklm5N3xCwuiy+/vKy8i0ifdsQP1sLgO4tZDSCaQUSnmC48khknGMV3D2Q==",
-            "dependencies": {
-                "get-intrinsic": "^1.2.2",
-                "has-tostringtag": "^1.0.0",
-                "hasown": "^2.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/es-to-primitive": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-            "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-            "dependencies": {
-                "is-callable": "^1.1.4",
-                "is-date-object": "^1.0.1",
-                "is-symbol": "^1.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/for-each": {
-            "version": "0.3.3",
-            "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
-            "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
-            "dependencies": {
-                "is-callable": "^1.1.3"
-            }
-        },
-        "node_modules/function-bind": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/function.prototype.name": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.6.tgz",
-            "integrity": "sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==",
-            "dependencies": {
-                "call-bind": "^1.0.2",
-                "define-properties": "^1.2.0",
-                "es-abstract": "^1.22.1",
-                "functions-have-names": "^1.2.3"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/functions-have-names": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
-            "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/get-intrinsic": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.2.tgz",
-            "integrity": "sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==",
-            "dependencies": {
-                "function-bind": "^1.1.2",
-                "has-proto": "^1.0.1",
-                "has-symbols": "^1.0.3",
-                "hasown": "^2.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/get-symbol-description": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
-            "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
-            "dependencies": {
-                "call-bind": "^1.0.2",
-                "get-intrinsic": "^1.1.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/globalthis": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
-            "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
-            "dependencies": {
-                "define-properties": "^1.1.3"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/gopd": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-            "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-            "dependencies": {
-                "get-intrinsic": "^1.1.3"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/has-bigints": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
-            "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/has-property-descriptors": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz",
-            "integrity": "sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==",
-            "dependencies": {
-                "get-intrinsic": "^1.2.2"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/has-proto": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
-            "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/has-symbols": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-            "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/has-tostringtag": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
-            "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
-            "dependencies": {
-                "has-symbols": "^1.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/hasown": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
-            "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
-            "dependencies": {
-                "function-bind": "^1.1.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/internal-slot": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.6.tgz",
-            "integrity": "sha512-Xj6dv+PsbtwyPpEflsejS+oIZxmMlV44zAhG479uYu89MsjcYOhCFnNyKrkJrihbsiasQyY0afoCl/9BLR65bg==",
-            "dependencies": {
-                "get-intrinsic": "^1.2.2",
-                "hasown": "^2.0.0",
-                "side-channel": "^1.0.4"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/is-arguments": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
-            "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
-            "dependencies": {
-                "call-bind": "^1.0.2",
-                "has-tostringtag": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-array-buffer": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
-            "integrity": "sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==",
-            "dependencies": {
-                "call-bind": "^1.0.2",
-                "get-intrinsic": "^1.2.0",
-                "is-typed-array": "^1.1.10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-bigint": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
-            "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
-            "dependencies": {
-                "has-bigints": "^1.0.1"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-boolean-object": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
-            "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
-            "dependencies": {
-                "call-bind": "^1.0.2",
-                "has-tostringtag": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-callable": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-            "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-date-object": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
-            "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
-            "dependencies": {
-                "has-tostringtag": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-map": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
-            "integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==",
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-negative-zero": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
-            "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-number-object": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
-            "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
-            "dependencies": {
-                "has-tostringtag": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-regex": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
-            "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
-            "dependencies": {
-                "call-bind": "^1.0.2",
-                "has-tostringtag": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-set": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
-            "integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==",
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-shared-array-buffer": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
-            "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
-            "dependencies": {
-                "call-bind": "^1.0.2"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-string": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
-            "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
-            "dependencies": {
-                "has-tostringtag": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-symbol": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
-            "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
-            "dependencies": {
-                "has-symbols": "^1.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-typed-array": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.12.tgz",
-            "integrity": "sha512-Z14TF2JNG8Lss5/HMqt0//T9JeHXttXy5pH/DBU4vi98ozO2btxzq9MwYDZYnKwU8nRsz/+GVFVRDq3DkVuSPg==",
-            "dependencies": {
-                "which-typed-array": "^1.1.11"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-weakref": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
-            "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
-            "dependencies": {
-                "call-bind": "^1.0.2"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/isarray": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-            "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
-        },
-        "node_modules/iterate-iterator": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/iterate-iterator/-/iterate-iterator-1.0.2.tgz",
-            "integrity": "sha512-t91HubM4ZDQ70M9wqp+pcNpu8OyJ9UAtXntT/Bcsvp5tZMnz9vRa+IunKXeI8AnfZMTv0jNuVEmGeLSMjVvfPw==",
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/iterate-value": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/iterate-value/-/iterate-value-1.0.2.tgz",
-            "integrity": "sha512-A6fMAio4D2ot2r/TYzr4yUWrmwNdsN5xL7+HUiyACE4DXm+q8HtPcnFTp+NnW3k4N05tZ7FVYFFb2CR13NxyHQ==",
-            "dependencies": {
-                "es-get-iterator": "^1.0.2",
-                "iterate-iterator": "^1.0.1"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/klona": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.5.tgz",
-            "integrity": "sha512-pJiBpiXMbt7dkzXe8Ghj/u4FfXOOa98fPW+bihOJ4SjnoijweJrNThJfd3ifXpXhREjpoF2mZVH1GfS9LV3kHQ==",
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.6.tgz",
+            "integrity": "sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 8"
             }
@@ -889,6 +295,7 @@
             "version": "2.7.0",
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
             "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+            "license": "MIT",
             "dependencies": {
                 "whatwg-url": "^5.0.0"
             },
@@ -904,39 +311,6 @@
                 }
             }
         },
-        "node_modules/object-inspect": {
-            "version": "1.13.1",
-            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
-            "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/object-keys": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/object.assign": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.5.tgz",
-            "integrity": "sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==",
-            "dependencies": {
-                "call-bind": "^1.0.5",
-                "define-properties": "^1.2.1",
-                "has-symbols": "^1.0.3",
-                "object-keys": "^1.1.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/prettier": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
@@ -949,22 +323,6 @@
                 "node": ">=10.13.0"
             }
         },
-        "node_modules/regexp.prototype.flags": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.1.tgz",
-            "integrity": "sha512-sy6TXMN+hnP/wMy+ISxg3krXx7BAtWVO4UouuCN/ziM9UEne0euamVNafDfvC83bRNr95y0V5iijeDQFUNpvrg==",
-            "dependencies": {
-                "call-bind": "^1.0.2",
-                "define-properties": "^1.2.0",
-                "set-function-name": "^2.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/retry": {
             "version": "0.13.1",
             "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
@@ -973,284 +331,61 @@
                 "node": ">= 4"
             }
         },
-        "node_modules/safe-array-concat": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.0.1.tgz",
-            "integrity": "sha512-6XbUAseYE2KtOuGueyeobCySj9L4+66Tn6KQMOPQJrAJEowYKW/YR/MGJZl7FdydUdaFu4LYyDZjxf4/Nmo23Q==",
-            "dependencies": {
-                "call-bind": "^1.0.2",
-                "get-intrinsic": "^1.2.1",
-                "has-symbols": "^1.0.3",
-                "isarray": "^2.0.5"
-            },
-            "engines": {
-                "node": ">=0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/safe-regex-test": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
-            "integrity": "sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==",
-            "dependencies": {
-                "call-bind": "^1.0.2",
-                "get-intrinsic": "^1.1.3",
-                "is-regex": "^1.1.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/set-function-length": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.1.1.tgz",
-            "integrity": "sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==",
-            "dependencies": {
-                "define-data-property": "^1.1.1",
-                "get-intrinsic": "^1.2.1",
-                "gopd": "^1.0.1",
-                "has-property-descriptors": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/set-function-name": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.1.tgz",
-            "integrity": "sha512-tMNCiqYVkXIZgc2Hnoy2IvC/f8ezc5koaRFkCjrpWzGpCd3qbZXPzVy9MAZzK1ch/X0jvSkojys3oqJN0qCmdA==",
-            "dependencies": {
-                "define-data-property": "^1.0.1",
-                "functions-have-names": "^1.2.3",
-                "has-property-descriptors": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/side-channel": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-            "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
-            "dependencies": {
-                "call-bind": "^1.0.0",
-                "get-intrinsic": "^1.0.2",
-                "object-inspect": "^1.9.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/stop-iteration-iterator": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.0.0.tgz",
-            "integrity": "sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==",
-            "dependencies": {
-                "internal-slot": "^1.0.4"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/string.prototype.trim": {
-            "version": "1.2.8",
-            "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.8.tgz",
-            "integrity": "sha512-lfjY4HcixfQXOfaqCvcBuOIapyaroTXhbkfJN3gcB1OtyupngWK4sEET9Knd0cXd28kTUqu/kHoV4HKSJdnjiQ==",
-            "dependencies": {
-                "call-bind": "^1.0.2",
-                "define-properties": "^1.2.0",
-                "es-abstract": "^1.22.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/string.prototype.trimend": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.7.tgz",
-            "integrity": "sha512-Ni79DqeB72ZFq1uH/L6zJ+DKZTkOtPIHovb3YZHQViE+HDouuU4mBrLOLDn5Dde3RF8qw5qVETEjhu9locMLvA==",
-            "dependencies": {
-                "call-bind": "^1.0.2",
-                "define-properties": "^1.2.0",
-                "es-abstract": "^1.22.1"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/string.prototype.trimstart": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.7.tgz",
-            "integrity": "sha512-NGhtDFu3jCEm7B4Fy0DpLewdJQOZcQ0rGbwQ/+stjnrp2i+rlKeCvos9hOIeCmqwratM47OBxY7uFZzjxHXmrg==",
-            "dependencies": {
-                "call-bind": "^1.0.2",
-                "define-properties": "^1.2.0",
-                "es-abstract": "^1.22.1"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
+        "node_modules/tiny-typed-emitter": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
+            "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==",
+            "license": "MIT"
         },
         "node_modules/tr46": {
             "version": "0.0.3",
             "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+            "license": "MIT"
         },
         "node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "license": "0BSD"
         },
-        "node_modules/typed-array-buffer": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.0.tgz",
-            "integrity": "sha512-Y8KTSIglk9OZEr8zywiIHG/kmQ7KWyjseXs1CbSo8vC42w7hg2HgYTxSWwP0+is7bWDc1H+Fo026CpHFwm8tkw==",
-            "dependencies": {
-                "call-bind": "^1.0.2",
-                "get-intrinsic": "^1.2.1",
-                "is-typed-array": "^1.1.10"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/typed-array-byte-length": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.0.tgz",
-            "integrity": "sha512-Or/+kvLxNpeQ9DtSydonMxCx+9ZXOswtwJn17SNLvhptaXYDJvkFFP5zbfU/uLmvnBJlI4yrnXRxpdWH/M5tNA==",
-            "dependencies": {
-                "call-bind": "^1.0.2",
-                "for-each": "^0.3.3",
-                "has-proto": "^1.0.1",
-                "is-typed-array": "^1.1.10"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/typed-array-byte-offset": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.0.tgz",
-            "integrity": "sha512-RD97prjEt9EL8YgAgpOkf3O4IF9lhJFr9g0htQkm0rchFp/Vx7LW5Q8fSXXub7BXAODyUQohRMyOc3faCPd0hg==",
-            "dependencies": {
-                "available-typed-arrays": "^1.0.5",
-                "call-bind": "^1.0.2",
-                "for-each": "^0.3.3",
-                "has-proto": "^1.0.1",
-                "is-typed-array": "^1.1.10"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/typed-array-length": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.4.tgz",
-            "integrity": "sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==",
-            "dependencies": {
-                "call-bind": "^1.0.2",
-                "for-each": "^0.3.3",
-                "is-typed-array": "^1.1.9"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/unbox-primitive": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
-            "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
-            "dependencies": {
-                "call-bind": "^1.0.2",
-                "has-bigints": "^1.0.2",
-                "has-symbols": "^1.0.3",
-                "which-boxed-primitive": "^1.0.2"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
+        "node_modules/undici-types": {
+            "version": "6.19.8",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+            "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+            "license": "MIT"
         },
         "node_modules/webidl-conversions": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+            "license": "BSD-2-Clause"
         },
         "node_modules/whatwg-url": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
             "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+            "license": "MIT",
             "dependencies": {
                 "tr46": "~0.0.3",
                 "webidl-conversions": "^3.0.0"
-            }
-        },
-        "node_modules/which-boxed-primitive": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
-            "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
-            "dependencies": {
-                "is-bigint": "^1.0.1",
-                "is-boolean-object": "^1.1.0",
-                "is-number-object": "^1.0.4",
-                "is-string": "^1.0.5",
-                "is-symbol": "^1.0.3"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/which-typed-array": {
-            "version": "1.1.13",
-            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.13.tgz",
-            "integrity": "sha512-P5Nra0qjSncduVPEAr7xhoF5guty49ArDTwzJ/yNuPIbZppyRxFQsRCWrocxIY+CnMVG+qfbU2FmDKyvSGClow==",
-            "dependencies": {
-                "available-typed-arrays": "^1.0.5",
-                "call-bind": "^1.0.4",
-                "for-each": "^0.3.3",
-                "gopd": "^1.0.1",
-                "has-tostringtag": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         }
     },
     "dependencies": {
         "@d-fischer/cache-decorators": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@d-fischer/cache-decorators/-/cache-decorators-3.0.0.tgz",
-            "integrity": "sha512-mYUCjrp5hJgimceC5bof3zzmElyxzW4ty+73IjY12wvxLAqsq0CbgLGspnJm6KgwEfGoeRnISZD4EXJidG3FvA==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@d-fischer/cache-decorators/-/cache-decorators-4.0.1.tgz",
+            "integrity": "sha512-HNYLBLWs/t28GFZZeqdIBqq8f37mqDIFO6xNPof94VjpKvuP6ROqCZGafx88dk5zZUlBfViV9jD8iNNlXfc4CA==",
             "requires": {
-                "@d-fischer/shared-utils": "^3.0.1",
-                "@types/node": "^14.14.22",
-                "tslib": "^2.1.0"
-            },
-            "dependencies": {
-                "@types/node": {
-                    "version": "14.18.18",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.18.tgz",
-                    "integrity": "sha512-B9EoJFjhqcQ9OmQrNorItO+OwEOORNn3S31WuiHvZY/dm9ajkB7AKD/8toessEtHHNL+58jofbq7hMMY9v4yig=="
-                }
+                "@d-fischer/shared-utils": "^3.6.3",
+                "tslib": "^2.6.2"
             }
         },
         "@d-fischer/cross-fetch": {
-            "version": "5.0.4",
-            "resolved": "https://registry.npmjs.org/@d-fischer/cross-fetch/-/cross-fetch-5.0.4.tgz",
-            "integrity": "sha512-u2IBCipsiE8565AbepyOrIk2LGuaIMr5ARFHHYmGmY9dp2HfX2iMqiLjPz0DnxH3ZBalYA4IxzxcstcgLIWRag==",
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/@d-fischer/cross-fetch/-/cross-fetch-5.0.5.tgz",
+            "integrity": "sha512-symjDUPInTrkfIsZc2n2mo9hiAJLcTJsZkNICjZajEWnWpJ3s3zn50/FY8xpNUAf5w3eFuQii2wxztTGpvG1Xg==",
             "requires": {
                 "node-fetch": "^2.6.12"
             }
@@ -1270,39 +405,25 @@
                 "tslib": "^2.0.3"
             }
         },
-        "@d-fischer/promise.allsettled": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/@d-fischer/promise.allsettled/-/promise.allsettled-2.0.2.tgz",
-            "integrity": "sha512-xY0vYDwJYFe22MS5ccQ50N4Mcc2nQ8J4eWE5Y354IxZwW32O5uTT6mmhFSuVF6ZrKvzHOCIrK+9WqOR6TI3tcA==",
-            "requires": {
-                "array.prototype.map": "^1.0.3",
-                "call-bind": "^1.0.2",
-                "define-properties": "^1.1.3",
-                "es-abstract": "^1.18.0-next.2",
-                "get-intrinsic": "^1.0.2",
-                "iterate-value": "^1.0.2"
-            }
-        },
         "@d-fischer/qs": {
             "version": "7.0.2",
             "resolved": "https://registry.npmjs.org/@d-fischer/qs/-/qs-7.0.2.tgz",
             "integrity": "sha512-yAu3xDooiL+ef84Jo8nLjDjWBRk7RXk163Y6aTvRB7FauYd3spQD/dWvgT7R4CrN54Juhrrc3dMY7mc+jZGurQ=="
         },
         "@d-fischer/rate-limiter": {
-            "version": "0.7.5",
-            "resolved": "https://registry.npmjs.org/@d-fischer/rate-limiter/-/rate-limiter-0.7.5.tgz",
-            "integrity": "sha512-Waclzcv7dpCHVbXsvrSxfsLI1q3bGjmisaxHxHu5OzepQH/gAtxP7aAqTM5Jr+yssq6UM0u0NTAXComCgfu00w==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@d-fischer/rate-limiter/-/rate-limiter-1.0.1.tgz",
+            "integrity": "sha512-Mq+0pAJsx92hP83cjmsrXQZVQJ+/+u1JFT6fjH8pj3yfUrbT3eDBsA+6J63eat+QaC+Mci78HdiBfpsdBkdwog==",
             "requires": {
-                "@d-fischer/logger": "^4.2.1",
-                "@d-fischer/promise.allsettled": "^2.0.2",
-                "@d-fischer/shared-utils": "^3.2.0",
-                "tslib": "^2.0.3"
+                "@d-fischer/logger": "^4.2.3",
+                "@d-fischer/shared-utils": "^3.6.3",
+                "tslib": "^2.6.2"
             }
         },
         "@d-fischer/shared-utils": {
-            "version": "3.6.3",
-            "resolved": "https://registry.npmjs.org/@d-fischer/shared-utils/-/shared-utils-3.6.3.tgz",
-            "integrity": "sha512-Lz+Qk1WJLVoeREOHPZcIDTHOoxecxMSG2sq+x1xWYCH1exqiMKMMx06pXdy15UzHG7ohvQRNXk2oHqZ9EOl9jQ==",
+            "version": "3.6.4",
+            "resolved": "https://registry.npmjs.org/@d-fischer/shared-utils/-/shared-utils-3.6.4.tgz",
+            "integrity": "sha512-BPkVLHfn2Lbyo/ENDBwtEB8JVQ+9OzkjJhUunLaxkw4k59YFlQxUUwlDBejVSFcpQT0t+D3CQlX+ySZnQj0wxw==",
             "requires": {
                 "tslib": "^2.4.1"
             }
@@ -1316,52 +437,52 @@
             }
         },
         "@twurple/api": {
-            "version": "7.0.6",
-            "resolved": "https://registry.npmjs.org/@twurple/api/-/api-7.0.6.tgz",
-            "integrity": "sha512-Fe8haADUI+m4juCuNxtkWBX2HkCU6FA2+2Biq2/KRTp50FVRCeOBdDQpkdM4r+T2KE0NaiTpiH2rtaRodkR/gQ==",
+            "version": "7.2.1",
+            "resolved": "https://registry.npmjs.org/@twurple/api/-/api-7.2.1.tgz",
+            "integrity": "sha512-fqoX87GyHRL4pSmgloF5Mfj2XDJMx8fWBbcl4JGG7bgF2jvH5X9p3nzH169zqwSU/etfUdfytyoQ7/r2R+G3cg==",
             "requires": {
-                "@d-fischer/cache-decorators": "^3.0.0",
+                "@d-fischer/cache-decorators": "^4.0.0",
                 "@d-fischer/cross-fetch": "^5.0.1",
                 "@d-fischer/detect-node": "^3.0.1",
                 "@d-fischer/logger": "^4.2.1",
-                "@d-fischer/rate-limiter": "^0.7.2",
+                "@d-fischer/rate-limiter": "^1.0.0",
                 "@d-fischer/shared-utils": "^3.6.1",
                 "@d-fischer/typed-event-emitter": "^3.3.1",
-                "@twurple/api-call": "7.0.6",
-                "@twurple/common": "7.0.6",
+                "@twurple/api-call": "7.2.1",
+                "@twurple/common": "7.2.1",
                 "retry": "^0.13.1",
                 "tslib": "^2.0.3"
             }
         },
         "@twurple/api-call": {
-            "version": "7.0.6",
-            "resolved": "https://registry.npmjs.org/@twurple/api-call/-/api-call-7.0.6.tgz",
-            "integrity": "sha512-3E9IAJRyRLji9bjmZzicWv/wP9aGVdIDkzaX4WaK3sTRC9EkZ3nWIxSj0WmJ977O2lDsUkpgxzwmskuDqdaTrQ==",
+            "version": "7.2.1",
+            "resolved": "https://registry.npmjs.org/@twurple/api-call/-/api-call-7.2.1.tgz",
+            "integrity": "sha512-x+p6fMleFA/pJHVu8tFpkDkARGGt30EAUA+cLc+dEtU1EpH1mv7nv5LLHh9NW9vdZpYp0jk5TyY/TSbHdj7Ggw==",
             "requires": {
                 "@d-fischer/cross-fetch": "^5.0.1",
                 "@d-fischer/qs": "^7.0.2",
                 "@d-fischer/shared-utils": "^3.6.1",
-                "@twurple/common": "7.0.6",
+                "@twurple/common": "7.2.1",
                 "tslib": "^2.0.3"
             }
         },
         "@twurple/auth": {
-            "version": "7.0.6",
-            "resolved": "https://registry.npmjs.org/@twurple/auth/-/auth-7.0.6.tgz",
-            "integrity": "sha512-kgjSdLRW9NKk9LD8dySkgjXDxzJQFAiNIBZFbQNgTqSn7A2ZwaxmapIxy7FcHyGV0MdRtimScnRbKK9Nm089Xw==",
+            "version": "7.2.1",
+            "resolved": "https://registry.npmjs.org/@twurple/auth/-/auth-7.2.1.tgz",
+            "integrity": "sha512-IGHsJ/g0RblRSBC59XKA9277rE5w1dAKdhCPQz1QwkWnt6fsUyVoD1ut+qZvjuh7ssX1SBtNzFqohydfmWZytg==",
             "requires": {
                 "@d-fischer/logger": "^4.2.1",
                 "@d-fischer/shared-utils": "^3.6.1",
                 "@d-fischer/typed-event-emitter": "^3.3.1",
-                "@twurple/api-call": "7.0.6",
-                "@twurple/common": "7.0.6",
+                "@twurple/api-call": "7.2.1",
+                "@twurple/common": "7.2.1",
                 "tslib": "^2.0.3"
             }
         },
         "@twurple/common": {
-            "version": "7.0.6",
-            "resolved": "https://registry.npmjs.org/@twurple/common/-/common-7.0.6.tgz",
-            "integrity": "sha512-38cufsx5k1ruUNrorXsiyTVBnFCXPFgr+MMkpMoFnh3T5G9drT3RkmE6Ss7oeaK6Glr/ihQNIPL6NzTJkGmXhA==",
+            "version": "7.2.1",
+            "resolved": "https://registry.npmjs.org/@twurple/common/-/common-7.2.1.tgz",
+            "integrity": "sha512-veLY5laA00dPuekAcpHN6GDvnr6s1uH7yBDebLC1NhpcLkQgiAlGA50RdNS5YeA3xz7kfE2MOcYSi2S6Qoc7EA==",
             "requires": {
                 "@d-fischer/shared-utils": "^3.6.1",
                 "klona": "^2.0.4",
@@ -1369,9 +490,9 @@
             }
         },
         "@types/angular": {
-            "version": "1.8.1",
-            "resolved": "https://registry.npmjs.org/@types/angular/-/angular-1.8.1.tgz",
-            "integrity": "sha512-8zEjTC3gpkva6/dbUkiSxIUGUxYm9HD/pJJ0lbqfEM2TWqi/3vs4VtgoFxVXt5bmuJ+6G2caO2HaMD+NzB1VwA=="
+            "version": "1.8.4",
+            "resolved": "https://registry.npmjs.org/@types/angular/-/angular-1.8.4.tgz",
+            "integrity": "sha512-wPS/ncJWhyxJsndsW1B6Ta8D4mi97x1yItSu+rkLDytU3oRIh2CFAjMuJceYwFAh9+DIohndWM0QBA9OU2Hv0g=="
         },
         "@types/body-parser": {
             "version": "1.19.2",
@@ -1391,23 +512,25 @@
             }
         },
         "@types/express": {
-            "version": "4.17.1",
-            "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.1.tgz",
-            "integrity": "sha512-VfH/XCP0QbQk5B5puLqTLEeFgR8lfCJHZJKkInZ9mkYd+u8byX0kztXEQxEk4wZXJs8HI+7km2ALXjn4YKcX9w==",
+            "version": "4.17.21",
+            "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
+            "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
             "requires": {
                 "@types/body-parser": "*",
-                "@types/express-serve-static-core": "*",
+                "@types/express-serve-static-core": "^4.17.33",
+                "@types/qs": "*",
                 "@types/serve-static": "*"
             }
         },
         "@types/express-serve-static-core": {
-            "version": "4.17.28",
-            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz",
-            "integrity": "sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==",
+            "version": "4.19.6",
+            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.6.tgz",
+            "integrity": "sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==",
             "requires": {
                 "@types/node": "*",
                 "@types/qs": "*",
-                "@types/range-parser": "*"
+                "@types/range-parser": "*",
+                "@types/send": "*"
             }
         },
         "@types/mime": {
@@ -1416,19 +539,31 @@
             "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw=="
         },
         "@types/node": {
-            "version": "18.18.2",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.2.tgz",
-            "integrity": "sha512-u1cis+7wLZMPI62EozwsqvgMZyauczyiqRRu/vcqZKI5N5yidrJHqOFxEg5seT8adc96Q6Yczg1c0DlqGtMJMw=="
+            "version": "20.17.12",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.12.tgz",
+            "integrity": "sha512-vo/wmBgMIiEA23A/knMfn/cf37VnuF52nZh5ZoW0GWt4e4sxNquibrMRJ7UQsA06+MBx9r/H1jsI9grYjQCQlw==",
+            "requires": {
+                "undici-types": "~6.19.2"
+            }
         },
         "@types/qs": {
-            "version": "6.9.7",
-            "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
-            "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw=="
+            "version": "6.9.18",
+            "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.18.tgz",
+            "integrity": "sha512-kK7dgTYDyGqS+e2Q4aK9X3D7q234CIZ1Bv0q/7Z5IwRDoADNU81xXJK/YVyLbLTZCoIwUoDoffFeF+p/eIklAA=="
         },
         "@types/range-parser": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
-            "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+            "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="
+        },
+        "@types/send": {
+            "version": "0.17.4",
+            "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
+            "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
+            "requires": {
+                "@types/mime": "^1",
+                "@types/node": "*"
+            }
         },
         "@types/serve-static": {
             "version": "1.13.10",
@@ -1439,421 +574,10 @@
                 "@types/node": "*"
             }
         },
-        "array-buffer-byte-length": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.0.tgz",
-            "integrity": "sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==",
-            "requires": {
-                "call-bind": "^1.0.2",
-                "is-array-buffer": "^3.0.1"
-            }
-        },
-        "array.prototype.map": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/array.prototype.map/-/array.prototype.map-1.0.6.tgz",
-            "integrity": "sha512-nK1psgF2cXqP3wSyCSq0Hc7zwNq3sfljQqaG27r/7a7ooNUnn5nGq6yYWyks9jMO5EoFQ0ax80hSg6oXSRNXaw==",
-            "requires": {
-                "call-bind": "^1.0.2",
-                "define-properties": "^1.2.0",
-                "es-abstract": "^1.22.1",
-                "es-array-method-boxes-properly": "^1.0.0",
-                "is-string": "^1.0.7"
-            }
-        },
-        "arraybuffer.prototype.slice": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.2.tgz",
-            "integrity": "sha512-yMBKppFur/fbHu9/6USUe03bZ4knMYiwFBcyiaXB8Go0qNehwX6inYPzK9U0NeQvGxKthcmHcaR8P5MStSRBAw==",
-            "requires": {
-                "array-buffer-byte-length": "^1.0.0",
-                "call-bind": "^1.0.2",
-                "define-properties": "^1.2.0",
-                "es-abstract": "^1.22.1",
-                "get-intrinsic": "^1.2.1",
-                "is-array-buffer": "^3.0.2",
-                "is-shared-array-buffer": "^1.0.2"
-            }
-        },
-        "available-typed-arrays": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
-            "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw=="
-        },
-        "call-bind": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.5.tgz",
-            "integrity": "sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==",
-            "requires": {
-                "function-bind": "^1.1.2",
-                "get-intrinsic": "^1.2.1",
-                "set-function-length": "^1.1.1"
-            }
-        },
-        "define-data-property": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.1.tgz",
-            "integrity": "sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==",
-            "requires": {
-                "get-intrinsic": "^1.2.1",
-                "gopd": "^1.0.1",
-                "has-property-descriptors": "^1.0.0"
-            }
-        },
-        "define-properties": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
-            "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-            "requires": {
-                "define-data-property": "^1.0.1",
-                "has-property-descriptors": "^1.0.0",
-                "object-keys": "^1.1.1"
-            }
-        },
-        "es-abstract": {
-            "version": "1.22.3",
-            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.22.3.tgz",
-            "integrity": "sha512-eiiY8HQeYfYH2Con2berK+To6GrK2RxbPawDkGq4UiCQQfZHb6wX9qQqkbpPqaxQFcl8d9QzZqo0tGE0VcrdwA==",
-            "requires": {
-                "array-buffer-byte-length": "^1.0.0",
-                "arraybuffer.prototype.slice": "^1.0.2",
-                "available-typed-arrays": "^1.0.5",
-                "call-bind": "^1.0.5",
-                "es-set-tostringtag": "^2.0.1",
-                "es-to-primitive": "^1.2.1",
-                "function.prototype.name": "^1.1.6",
-                "get-intrinsic": "^1.2.2",
-                "get-symbol-description": "^1.0.0",
-                "globalthis": "^1.0.3",
-                "gopd": "^1.0.1",
-                "has-property-descriptors": "^1.0.0",
-                "has-proto": "^1.0.1",
-                "has-symbols": "^1.0.3",
-                "hasown": "^2.0.0",
-                "internal-slot": "^1.0.5",
-                "is-array-buffer": "^3.0.2",
-                "is-callable": "^1.2.7",
-                "is-negative-zero": "^2.0.2",
-                "is-regex": "^1.1.4",
-                "is-shared-array-buffer": "^1.0.2",
-                "is-string": "^1.0.7",
-                "is-typed-array": "^1.1.12",
-                "is-weakref": "^1.0.2",
-                "object-inspect": "^1.13.1",
-                "object-keys": "^1.1.1",
-                "object.assign": "^4.1.4",
-                "regexp.prototype.flags": "^1.5.1",
-                "safe-array-concat": "^1.0.1",
-                "safe-regex-test": "^1.0.0",
-                "string.prototype.trim": "^1.2.8",
-                "string.prototype.trimend": "^1.0.7",
-                "string.prototype.trimstart": "^1.0.7",
-                "typed-array-buffer": "^1.0.0",
-                "typed-array-byte-length": "^1.0.0",
-                "typed-array-byte-offset": "^1.0.0",
-                "typed-array-length": "^1.0.4",
-                "unbox-primitive": "^1.0.2",
-                "which-typed-array": "^1.1.13"
-            }
-        },
-        "es-array-method-boxes-properly": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
-            "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA=="
-        },
-        "es-get-iterator": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
-            "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
-            "requires": {
-                "call-bind": "^1.0.2",
-                "get-intrinsic": "^1.1.3",
-                "has-symbols": "^1.0.3",
-                "is-arguments": "^1.1.1",
-                "is-map": "^2.0.2",
-                "is-set": "^2.0.2",
-                "is-string": "^1.0.7",
-                "isarray": "^2.0.5",
-                "stop-iteration-iterator": "^1.0.0"
-            }
-        },
-        "es-set-tostringtag": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.2.tgz",
-            "integrity": "sha512-BuDyupZt65P9D2D2vA/zqcI3G5xRsklm5N3xCwuiy+/vKy8i0ifdsQP1sLgO4tZDSCaQUSnmC48khknGMV3D2Q==",
-            "requires": {
-                "get-intrinsic": "^1.2.2",
-                "has-tostringtag": "^1.0.0",
-                "hasown": "^2.0.0"
-            }
-        },
-        "es-to-primitive": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-            "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-            "requires": {
-                "is-callable": "^1.1.4",
-                "is-date-object": "^1.0.1",
-                "is-symbol": "^1.0.2"
-            }
-        },
-        "for-each": {
-            "version": "0.3.3",
-            "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
-            "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
-            "requires": {
-                "is-callable": "^1.1.3"
-            }
-        },
-        "function-bind": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
-        },
-        "function.prototype.name": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.6.tgz",
-            "integrity": "sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==",
-            "requires": {
-                "call-bind": "^1.0.2",
-                "define-properties": "^1.2.0",
-                "es-abstract": "^1.22.1",
-                "functions-have-names": "^1.2.3"
-            }
-        },
-        "functions-have-names": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
-            "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ=="
-        },
-        "get-intrinsic": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.2.tgz",
-            "integrity": "sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==",
-            "requires": {
-                "function-bind": "^1.1.2",
-                "has-proto": "^1.0.1",
-                "has-symbols": "^1.0.3",
-                "hasown": "^2.0.0"
-            }
-        },
-        "get-symbol-description": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
-            "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
-            "requires": {
-                "call-bind": "^1.0.2",
-                "get-intrinsic": "^1.1.1"
-            }
-        },
-        "globalthis": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
-            "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
-            "requires": {
-                "define-properties": "^1.1.3"
-            }
-        },
-        "gopd": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-            "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-            "requires": {
-                "get-intrinsic": "^1.1.3"
-            }
-        },
-        "has-bigints": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
-            "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ=="
-        },
-        "has-property-descriptors": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz",
-            "integrity": "sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==",
-            "requires": {
-                "get-intrinsic": "^1.2.2"
-            }
-        },
-        "has-proto": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
-            "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg=="
-        },
-        "has-symbols": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-            "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
-        },
-        "has-tostringtag": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
-            "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
-            "requires": {
-                "has-symbols": "^1.0.2"
-            }
-        },
-        "hasown": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
-            "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
-            "requires": {
-                "function-bind": "^1.1.2"
-            }
-        },
-        "internal-slot": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.6.tgz",
-            "integrity": "sha512-Xj6dv+PsbtwyPpEflsejS+oIZxmMlV44zAhG479uYu89MsjcYOhCFnNyKrkJrihbsiasQyY0afoCl/9BLR65bg==",
-            "requires": {
-                "get-intrinsic": "^1.2.2",
-                "hasown": "^2.0.0",
-                "side-channel": "^1.0.4"
-            }
-        },
-        "is-arguments": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
-            "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
-            "requires": {
-                "call-bind": "^1.0.2",
-                "has-tostringtag": "^1.0.0"
-            }
-        },
-        "is-array-buffer": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
-            "integrity": "sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==",
-            "requires": {
-                "call-bind": "^1.0.2",
-                "get-intrinsic": "^1.2.0",
-                "is-typed-array": "^1.1.10"
-            }
-        },
-        "is-bigint": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
-            "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
-            "requires": {
-                "has-bigints": "^1.0.1"
-            }
-        },
-        "is-boolean-object": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
-            "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
-            "requires": {
-                "call-bind": "^1.0.2",
-                "has-tostringtag": "^1.0.0"
-            }
-        },
-        "is-callable": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-            "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="
-        },
-        "is-date-object": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
-            "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
-            "requires": {
-                "has-tostringtag": "^1.0.0"
-            }
-        },
-        "is-map": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
-            "integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg=="
-        },
-        "is-negative-zero": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
-            "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA=="
-        },
-        "is-number-object": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
-            "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
-            "requires": {
-                "has-tostringtag": "^1.0.0"
-            }
-        },
-        "is-regex": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
-            "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
-            "requires": {
-                "call-bind": "^1.0.2",
-                "has-tostringtag": "^1.0.0"
-            }
-        },
-        "is-set": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
-            "integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g=="
-        },
-        "is-shared-array-buffer": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
-            "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
-            "requires": {
-                "call-bind": "^1.0.2"
-            }
-        },
-        "is-string": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
-            "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
-            "requires": {
-                "has-tostringtag": "^1.0.0"
-            }
-        },
-        "is-symbol": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
-            "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
-            "requires": {
-                "has-symbols": "^1.0.2"
-            }
-        },
-        "is-typed-array": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.12.tgz",
-            "integrity": "sha512-Z14TF2JNG8Lss5/HMqt0//T9JeHXttXy5pH/DBU4vi98ozO2btxzq9MwYDZYnKwU8nRsz/+GVFVRDq3DkVuSPg==",
-            "requires": {
-                "which-typed-array": "^1.1.11"
-            }
-        },
-        "is-weakref": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
-            "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
-            "requires": {
-                "call-bind": "^1.0.2"
-            }
-        },
-        "isarray": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-            "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
-        },
-        "iterate-iterator": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/iterate-iterator/-/iterate-iterator-1.0.2.tgz",
-            "integrity": "sha512-t91HubM4ZDQ70M9wqp+pcNpu8OyJ9UAtXntT/Bcsvp5tZMnz9vRa+IunKXeI8AnfZMTv0jNuVEmGeLSMjVvfPw=="
-        },
-        "iterate-value": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/iterate-value/-/iterate-value-1.0.2.tgz",
-            "integrity": "sha512-A6fMAio4D2ot2r/TYzr4yUWrmwNdsN5xL7+HUiyACE4DXm+q8HtPcnFTp+NnW3k4N05tZ7FVYFFb2CR13NxyHQ==",
-            "requires": {
-                "es-get-iterator": "^1.0.2",
-                "iterate-iterator": "^1.0.1"
-            }
-        },
         "klona": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.5.tgz",
-            "integrity": "sha512-pJiBpiXMbt7dkzXe8Ghj/u4FfXOOa98fPW+bihOJ4SjnoijweJrNThJfd3ifXpXhREjpoF2mZVH1GfS9LV3kHQ=="
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.6.tgz",
+            "integrity": "sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA=="
         },
         "moment": {
             "version": "2.29.4",
@@ -1868,137 +592,21 @@
                 "whatwg-url": "^5.0.0"
             }
         },
-        "object-inspect": {
-            "version": "1.13.1",
-            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
-            "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ=="
-        },
-        "object-keys": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
-        },
-        "object.assign": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.5.tgz",
-            "integrity": "sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==",
-            "requires": {
-                "call-bind": "^1.0.5",
-                "define-properties": "^1.2.1",
-                "has-symbols": "^1.0.3",
-                "object-keys": "^1.1.1"
-            }
-        },
         "prettier": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
             "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
             "dev": true
         },
-        "regexp.prototype.flags": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.1.tgz",
-            "integrity": "sha512-sy6TXMN+hnP/wMy+ISxg3krXx7BAtWVO4UouuCN/ziM9UEne0euamVNafDfvC83bRNr95y0V5iijeDQFUNpvrg==",
-            "requires": {
-                "call-bind": "^1.0.2",
-                "define-properties": "^1.2.0",
-                "set-function-name": "^2.0.0"
-            }
-        },
         "retry": {
             "version": "0.13.1",
             "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
             "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="
         },
-        "safe-array-concat": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.0.1.tgz",
-            "integrity": "sha512-6XbUAseYE2KtOuGueyeobCySj9L4+66Tn6KQMOPQJrAJEowYKW/YR/MGJZl7FdydUdaFu4LYyDZjxf4/Nmo23Q==",
-            "requires": {
-                "call-bind": "^1.0.2",
-                "get-intrinsic": "^1.2.1",
-                "has-symbols": "^1.0.3",
-                "isarray": "^2.0.5"
-            }
-        },
-        "safe-regex-test": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
-            "integrity": "sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==",
-            "requires": {
-                "call-bind": "^1.0.2",
-                "get-intrinsic": "^1.1.3",
-                "is-regex": "^1.1.4"
-            }
-        },
-        "set-function-length": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.1.1.tgz",
-            "integrity": "sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==",
-            "requires": {
-                "define-data-property": "^1.1.1",
-                "get-intrinsic": "^1.2.1",
-                "gopd": "^1.0.1",
-                "has-property-descriptors": "^1.0.0"
-            }
-        },
-        "set-function-name": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.1.tgz",
-            "integrity": "sha512-tMNCiqYVkXIZgc2Hnoy2IvC/f8ezc5koaRFkCjrpWzGpCd3qbZXPzVy9MAZzK1ch/X0jvSkojys3oqJN0qCmdA==",
-            "requires": {
-                "define-data-property": "^1.0.1",
-                "functions-have-names": "^1.2.3",
-                "has-property-descriptors": "^1.0.0"
-            }
-        },
-        "side-channel": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-            "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
-            "requires": {
-                "call-bind": "^1.0.0",
-                "get-intrinsic": "^1.0.2",
-                "object-inspect": "^1.9.0"
-            }
-        },
-        "stop-iteration-iterator": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.0.0.tgz",
-            "integrity": "sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==",
-            "requires": {
-                "internal-slot": "^1.0.4"
-            }
-        },
-        "string.prototype.trim": {
-            "version": "1.2.8",
-            "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.8.tgz",
-            "integrity": "sha512-lfjY4HcixfQXOfaqCvcBuOIapyaroTXhbkfJN3gcB1OtyupngWK4sEET9Knd0cXd28kTUqu/kHoV4HKSJdnjiQ==",
-            "requires": {
-                "call-bind": "^1.0.2",
-                "define-properties": "^1.2.0",
-                "es-abstract": "^1.22.1"
-            }
-        },
-        "string.prototype.trimend": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.7.tgz",
-            "integrity": "sha512-Ni79DqeB72ZFq1uH/L6zJ+DKZTkOtPIHovb3YZHQViE+HDouuU4mBrLOLDn5Dde3RF8qw5qVETEjhu9locMLvA==",
-            "requires": {
-                "call-bind": "^1.0.2",
-                "define-properties": "^1.2.0",
-                "es-abstract": "^1.22.1"
-            }
-        },
-        "string.prototype.trimstart": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.7.tgz",
-            "integrity": "sha512-NGhtDFu3jCEm7B4Fy0DpLewdJQOZcQ0rGbwQ/+stjnrp2i+rlKeCvos9hOIeCmqwratM47OBxY7uFZzjxHXmrg==",
-            "requires": {
-                "call-bind": "^1.0.2",
-                "define-properties": "^1.2.0",
-                "es-abstract": "^1.22.1"
-            }
+        "tiny-typed-emitter": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
+            "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA=="
         },
         "tr46": {
             "version": "0.0.3",
@@ -2006,63 +614,14 @@
             "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
         },
         "tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         },
-        "typed-array-buffer": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.0.tgz",
-            "integrity": "sha512-Y8KTSIglk9OZEr8zywiIHG/kmQ7KWyjseXs1CbSo8vC42w7hg2HgYTxSWwP0+is7bWDc1H+Fo026CpHFwm8tkw==",
-            "requires": {
-                "call-bind": "^1.0.2",
-                "get-intrinsic": "^1.2.1",
-                "is-typed-array": "^1.1.10"
-            }
-        },
-        "typed-array-byte-length": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.0.tgz",
-            "integrity": "sha512-Or/+kvLxNpeQ9DtSydonMxCx+9ZXOswtwJn17SNLvhptaXYDJvkFFP5zbfU/uLmvnBJlI4yrnXRxpdWH/M5tNA==",
-            "requires": {
-                "call-bind": "^1.0.2",
-                "for-each": "^0.3.3",
-                "has-proto": "^1.0.1",
-                "is-typed-array": "^1.1.10"
-            }
-        },
-        "typed-array-byte-offset": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.0.tgz",
-            "integrity": "sha512-RD97prjEt9EL8YgAgpOkf3O4IF9lhJFr9g0htQkm0rchFp/Vx7LW5Q8fSXXub7BXAODyUQohRMyOc3faCPd0hg==",
-            "requires": {
-                "available-typed-arrays": "^1.0.5",
-                "call-bind": "^1.0.2",
-                "for-each": "^0.3.3",
-                "has-proto": "^1.0.1",
-                "is-typed-array": "^1.1.10"
-            }
-        },
-        "typed-array-length": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.4.tgz",
-            "integrity": "sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==",
-            "requires": {
-                "call-bind": "^1.0.2",
-                "for-each": "^0.3.3",
-                "is-typed-array": "^1.1.9"
-            }
-        },
-        "unbox-primitive": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
-            "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
-            "requires": {
-                "call-bind": "^1.0.2",
-                "has-bigints": "^1.0.2",
-                "has-symbols": "^1.0.3",
-                "which-boxed-primitive": "^1.0.2"
-            }
+        "undici-types": {
+            "version": "6.19.8",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+            "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
         },
         "webidl-conversions": {
             "version": "3.0.1",
@@ -2076,30 +635,6 @@
             "requires": {
                 "tr46": "~0.0.3",
                 "webidl-conversions": "^3.0.0"
-            }
-        },
-        "which-boxed-primitive": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
-            "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
-            "requires": {
-                "is-bigint": "^1.0.1",
-                "is-boolean-object": "^1.1.0",
-                "is-number-object": "^1.0.4",
-                "is-string": "^1.0.5",
-                "is-symbol": "^1.0.3"
-            }
-        },
-        "which-typed-array": {
-            "version": "1.1.13",
-            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.13.tgz",
-            "integrity": "sha512-P5Nra0qjSncduVPEAr7xhoF5guty49ArDTwzJ/yNuPIbZppyRxFQsRCWrocxIY+CnMVG+qfbU2FmDKyvSGClow==",
-            "requires": {
-                "available-typed-arrays": "^1.0.5",
-                "call-bind": "^1.0.4",
-                "for-each": "^0.3.3",
-                "gopd": "^1.0.1",
-                "has-tostringtag": "^1.0.0"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@crowbartools/firebot-custom-scripts-types",
-    "version": "5.63.2",
+    "version": "5.64.0",
     "description": "Types for Firebot's Custom Scripts",
     "main": "",
     "scripts": {
@@ -21,15 +21,16 @@
         "prettier": "2.2.1"
     },
     "dependencies": {
-        "@twurple/api": "^7.0.6",
-        "@twurple/auth": "^7.0.6",
-        "@types/angular": "^1.8.1",
-        "@types/express": "^4.17.1",
-        "@types/node": "^18.18.2",
-        "moment": "^2.24.0"
+        "@twurple/api": "^7.2.1",
+        "@twurple/auth": "^7.2.1",
+        "@types/angular": "^1.8.4",
+        "@types/express": "^4.17.21",
+        "@types/node": "^20.17.12",
+        "moment": "^2.24.0",
+        "tiny-typed-emitter": "^2.1.0"
     },
     "volta": {
-        "node": "14.18.1",
-        "npm": "8.16.0"
+        "node": "20.18.1",
+        "npm": "10.8.1"
     }
 }

--- a/types/modules/http-server-manager.ts
+++ b/types/modules/http-server-manager.ts
@@ -1,6 +1,6 @@
-import EventEmitter from "events";
-import { Express } from "express";
-import { Server } from "http";
+import { Express, Request, Response } from "express";
+import http from "http";
+import { TypedEmitter } from "tiny-typed-emitter";
 
 // https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods
 type HttpMethod =
@@ -14,23 +14,100 @@ type HttpMethod =
     | "OPTIONS"
     | "TRACE";
 
-export type HttpServerManager = {
-    sendToOverlay(
+export interface InvokePluginWebsocketMessage<TData = unknown> {
+    type: "invoke";
+    name: "plugin";
+    pluginName: string;
+    id: string | number;
+    data?: TData;
+};
+
+interface ServerManagerEvents {
+    "overlay-connected"(instanceName?: string): void;
+    "overlay-event"<TEvent = unknown>(event: TEvent): void;
+}
+
+export type HttpServerManager = TypedEmitter<ServerManagerEvents> & {
+    /** Send an event to the overlay.
+     * @template TData The type of the data to send with the event. *Should* extend from
+     * `Record<string, unknown>`, but doesn't *need* to.
+     * @param eventName The name of the event.
+     * @param meta (optional) Data pertinent for the event.
+     * @param overlayInstance (optional) The particular overlay instance to send the event to.
+     */
+    sendToOverlay<TData = unknown>(
         eventName: string,
-        meta?: Record<string, unknown>,
-        overlayInstance?: any
+        meta?: TData,
+        overlayInstance?: string
     ): void;
+
+    /** Register a custom route with the HTTP server manager. The full URL to invoke the callback
+     * would be similar to: `http://localhost:7472/integrations/${prefix}/${route}`
+     * @param prefix The initial portion of the URL, which should generally be unique for a given
+     * custom plugin.
+     * @param route The specific route to respond to.
+     * @param method The HTTP method to respond to.
+     * @param callback A callback to invoke when a request is made to the custom route. 
+     * @returns `true` if the custom route was successfully registered; otherwise, `false`.
+     * @see HttpServerManager.unregisterCustomRoute
+     */
     registerCustomRoute(
         prefix: string,
         route: string,
         method: HttpMethod,
-        callback: Function
+        callback: (req: Request, res: Response) => Promise<void> | void
     ): boolean;
+
+    /** Unregister a custom route from the HTTP server manager. The full URL to invoke the callback
+     * would be similar to: `http://localhost:7472/integrations/${prefix}/${route}`
+     * @param prefix The initial portion of the URL, which should generally be unique for a given
+     * custom plugin.
+     * @param route The specific route to unregister.
+     * @param method The HTTP method to unregister.
+     * @returns `true` if the custom route was successfully unregistered; otherwise, `false`.
+     * @see HttpServerManager.registerCustomRoute
+     */
     unregisterCustomRoute(
         prefix: string,
         route: string,
         method: HttpMethod
     ): boolean;
-    startHttpServer(name: string, port: number, instance: Express): Server;
+
+    startHttpServer(name: string, port: number, instance: Express): http.Server;
     stopHttpServer(name: string): boolean;
+
+    /** Register a custom plugin message with the WebSocket server. WebSocket messages should
+     * match the `InvokePluginWebsocketMessage` type in order to get routed to the callback.
+     * @template TData The type of data passed to the callback function.
+     * @param pluginName The name of the plugin to register.
+     * @param callback The callback to be invoked when a web socket "plugin" message is received.
+     * @returns `true` if the listener was successfully registered; otherwise, `false`, such as if
+     * a listener for that `pluginName` had previously been registered.
+     * @see InvokePluginWebsocketMessage
+     * @see HttpServerManager.unregisterCustomWebSocketListener
+     */
+    registerCustomWebSocketListener<TData = unknown>(
+        pluginName: string,
+        callback: (data: TData) => Promise<void> | void
+    ): boolean;
+
+    /** Trigger a custom event in the WebSocket server manager.
+     * @template TEvent The type of event data to send with the event.
+     * @param eventType The name of the custom-event to trigger.
+     * @param payload The associated data for the event.
+     */
+    triggerCustomWebSocketEvent<TEvent extends object = object>(
+        eventType: string,
+        payload?: TEvent
+    ): void;
+
+    /** Unregister a custom message listener from the WebSocket server.
+     * @param pluginName The same `pluginName` that was used to register the listener.
+     * @returns `true` if the listener was successfully unregistered; otherwise, `false`, such as
+     * if no listeners were registered for the `pluginName`.
+     * @see HttpServerManager.registerCustomWebSocketListener
+     */
+    unregisterCustomWebSocketListener(
+        pluginName: string
+    ): boolean;
 };

--- a/types/settings.d.ts
+++ b/types/settings.d.ts
@@ -1,3 +1,5 @@
+import type { TypedEmitter } from "tiny-typed-emitter";
+
 export enum FirebotAutoUpdateLevel {
     Off = 0,
     Bugfix = 1,
@@ -11,79 +13,252 @@ export type FirebotAudioOutputDevice = {
     deviceId: string;
 };
 
-export type FirebotSettings = {
+export type FirebotSettingsTypes = {
+    ActiveChatUserListTimeout: number;
+    ActiveProfiles: string[];
+    AllowCommandsInSharedChat: boolean;
+    AllowQuoteCSVDownloads: boolean;
+    AllowedActivityEvents: string[];
+    AudioOutputDevice: FirebotAudioOutputDevice;
+    AutoFlagBots: boolean;
+    AutoUpdateLevel: FirebotAutoUpdateLevel;
+    BackupBeforeUpdates: boolean;
+    BackupIgnoreResources: boolean;
+    BackupKeepAll: boolean;
+    BackupLocation: string;
+    BackupOnceADay: boolean;
+    BackupOnExit: boolean;
+    ChatAlternateBackgrounds: boolean;
+    ChatAvatars: boolean;
+    ChatCompactMode: boolean;
+    ChatCustomFontFamily: string;
+    ChatCustomFontFamilyEnabled: boolean;
+    ChatCustomFontSize: number;
+    ChatCustomFontSizeEnabled: boolean;
+    ChatHideBotAccountMessages: boolean;
+    ChatHideDeletedMessages: boolean;
+    ChatHideWhispers: boolean;
+    ChatPronouns: boolean;
+    ChatShowBttvEmotes: boolean;
+    ChatShowFfzEmotes: boolean;
+    ChatShowSevenTvEmotes: boolean;
+    ChatTaggedNotificationSound: { name: string, path?: string | undefined };
+    ChatTaggedNotificationVolume: number;
+    ChatTimestamps: boolean;
+    ClearChatFeedMode: "never" | "onlyStreamer" | "always";
+    ClearCustomScriptCache: boolean;
+    CopiedOverlayVersion: string;
+    DashboardLayout: object; //TODO
+    DebugMode: boolean;
+    DefaultToAdvancedCommandMode: boolean;
+    DefaultTtsVoiceId: string;
+    DeleteProfile: string;
+    EventSettings: object; //TODO
+    FirstTimeUse: boolean;
+    ForceOverlayEffectsToContinueOnRefresh: boolean;
+    IgnoreSubsequentSubEventsAfterCommunitySub: boolean;
+    JustUpdated: boolean;
+    LastBackupDate: Date;
+    LegacySortTagsImported: boolean;
+    LoggedInProfile: string;
+    MaxBackupCount: number | "All";
+    MinimizeToTray: boolean;
+    NotifyOnBeta: boolean;
+    OpenStreamPreviewOnLaunch: boolean;
+    OverlayInstances: string[];
+    PersistCustomVariables: boolean;
+    QuickActions: object; //TODO
+    RunCustomScripts: boolean;
+    SeenAdvancedCommandModePopup: boolean;
+    ShowAdBreakIndicator: boolean;
+    ShowActivityFeed: boolean;
+    ShowChatViewerList: boolean;
+    ShowHypeTrainIndicator: boolean;
+    ShowUptimeStat: boolean;
+    ShowViewerCountStat: boolean;
+    SidebarControlledServices: string[];
+    SidebarExpanded: boolean;
+    SoundsEnabled: "On" | "Off";
+    Theme: string;
+    TriggerUpcomingAdBreakMinutes: number;
+    TtsVoiceRate: number;
+    TtsVoiceVolume: number;
+    UseOverlayInstances: boolean;
+    ViewerDB: boolean;
+    ViewerListPageSize: number;
+    WebOnlineCheckin: boolean;
+    WebServerPort: number;
+    WhileLoopEnabled: boolean;
+    WysiwygBackground: "black" | "white";
+}
+
+type UpdatedEvents = {
+    [Key in keyof FirebotSettingsTypes as `settings:setting-updated:${Key}`]: (data: FirebotSettingsTypes[Key]) => void;
+};
+type DeletedEvents = {
+    [Key in keyof FirebotSettingsTypes as `settings:setting-deleted:${Key}`]: () => void;
+};
+interface SettingsEvents extends DeletedEvents, UpdatedEvents {}
+
+export type FirebotSettings = TypedEmitter<SettingsEvents> & {
+    /** Delete a Firebot setting, and emits a "settings:setting-deleted:settingName"
+     * event with no data.
+     * @param settingName The name of the setting to delete.
+     */
+    deleteSetting<SettingName extends keyof FirebotSettingsTypes>(
+        settingName: SettingName
+    ): void;
+
+    /** Flushes the settings cache, forcing all settings to be retrieved from file on the next retrieval. */
     flushSettingsCache(): void;
 
-    /** @returns JsonDB */
-    getSettingsFile(): any;
+    /** Get a plugin setting or its default.
+     * @template T The type of the settings value.
+     * @param pluginName The name of the plugin.
+     * @param settingName The name of the setting.
+     * @param forceCacheUpdate (optional; default `false`) `true` to force an update to the settings cache.
+     * @param defaultValue (optional) The default value to return if one isn't explicitly defined.
+     * @returns The saved plugin setting value, or the default if one doesn't exist.
+     */
+    getPluginSetting<T = unknown>(
+        pluginName: string,
+        settingName: string,
+        forceCacheUpdate?: boolean,
+        defaultValue?: T
+    ): T | undefined | null;
 
-    pushDataToFile(path: string, data: any): void;
-    getDataFromFile(path: string, forceCacheUpdate?: boolean): any;
+    /** Get a Firebot setting value or its default.
+     * @param settingName The name of the setting to get.
+     * @param forceCacheUpdate (optional; default `false`) If `true`, forces an update to the settings cache.
+     * @returns The setting value, or the default if one isn't explicitly set.
+     */
+    getSetting<SettingName extends keyof FirebotSettingsTypes>(
+        settingName: SettingName,
+        forceCacheUpdate?: boolean
+    ): FirebotSettingsTypes[SettingName] | null | undefined;
 
+    /** Get the JSON data path for a specific Firebot setting in the settings file.
+     * @param settingName Name of the setting.
+     * @returns A string representing the full JSON path of the setting data.
+     */
+    getSettingPath<SettingName extends keyof FirebotSettingsTypes>(
+        settingName: SettingName
+    ): string;
+
+    /** Save a Firebot setting, and emits an "settings:setting-updated:settingName" event
+     * with the provided `data`.
+     * @param settingName The name of the setting to save.
+     * @param data The data to save to the setting.
+     */
+    saveSetting<SettingName extends keyof FirebotSettingsTypes>(
+        settingName: SettingName,
+        data: FirebotSettingsTypes[SettingName]
+    ): void;
+
+
+    // Everything below this is deprecated. Leaving them for back compat with scripts.
+    // You should use either getSetting or saveSetting with the relevant setting name.
+
+    /** @deprecated Use `getSetting("EventSettings")` instead */
     getEventSettings(): unknown;
 
-    isCustomScriptsEnabled(): boolean;
-    setCustomScriptsEnabled(enabled: boolean): void;
-
+    /** @deprecated Use `getSetting("IgnoreSubsequentSubEventsAfterCommunitySub")` instead */
     ignoreSubsequentSubEventsAfterCommunitySub(): void;
 
+    /** @deprecated Use `getSetting("JustUpdated")` instead */
     hasJustUpdated(): boolean;
+    /** @deprecated Use `saveSetting("JustUpdated", value)` instead */
     setJustUpdated(justUpdated: boolean): void;
 
+    /** @deprecated Use `getSetting("CopiedOverlayVersion")` instead */
     getOverlayVersion(): string;
+    /** @deprecated Use `saveSetting("CopiedOverlayVersion", value)` instead */
     setOverlayVersion(newVersion: string): void;
 
+    /** @deprecated Use `getSetting("ClearCustomScriptCache")` instead */
     getClearCustomScriptCache(): boolean;
+    /** @deprecated Use `saveSetting("ClearCustomScriptCache", value)` instead */
     setClearCustomScriptCache(clear: boolean): void;
 
+    /** @deprecated Use `getSetting("RunCustomScripts")` instead */
+    isCustomScriptsEnabled(): boolean;
+    /** @deprecated Use `getSetting("RunCustomScripts")` instead */
     getCustomScriptsEnabled(): boolean;
+    /** @deprecated Use `saveSetting("RunCustomScripts", value)` instead */
     setCustomScriptsEnabled(enabled: boolean): void;
 
+    /** @deprecated Use `getSetting("PersistCustomVariables")` instead */
     getPersistCustomVariables(): boolean;
+    /** @deprecated Use `saveSetting("PersistCustomVariables", value)` instead */
     setPersistCustomVariables(enabled: boolean): void;
 
+    /** @deprecated Use `getSetting("UseOverlayInstances")` instead */
     useOverlayInstances(): boolean;
+    /** @deprecated Use `saveSetting("UseOverlayInstances", value)` instead */
     setUseOverlayInstances(oi: boolean): void;
 
-    getOverlayInstances(): unknown[];
-    setOverlayInstances(ois: unknown[]): void;
+    /** @deprecated Use `getSetting("OverlayInstances")` instead */
+    getOverlayInstances(): string[];
+    /** @deprecated Use `saveSetting("OverlayInstances", value)` instead */
+    setOverlayInstances(ois: string[]): void;
 
+    /** @deprecated Use `getSetting("BackupKeepAll")` instead */
     backupKeepAll(): boolean;
 
+    /** @deprecated Use `getSetting("BackupOnExit")` instead */
     backupOnExit(): boolean;
 
+    /** @deprecated Use `getSetting("BackupBeforeUpdates")` instead */
     backupBeforeUpdates(): boolean;
 
+    /** @deprecated Use `getSetting("BackupOnceADay")` instead */
     backupOnceADay(): boolean;
+    /** @deprecated Use `saveSetting("BackupOnceADay", value)` instead */
     setBackupOnceADay(backupOnceADay: boolean): void;
 
+    /** @deprecated Use `getSetting("LastBackupDate")` instead */
     lastBackupDate(): Date;
+    /** @deprecated Use `saveSetting("LastBackupDate", value)` instead */
     setLastBackupDate(lastBackup: Date): void;
 
+    /** @deprecated Use `getSetting("MaxBackupCount")` instead */
     maxBackupCount(): number;
+    /** @deprecated Use `getSetting("MaxBackupCount")` instead */
     setMaxBackupCount(maxBackupCount: number): void;
 
+    /** @deprecated Use `getSetting("AllowQuoteCSVDownloads")` instead */
     getAllowQuoteCSVDownloads(): boolean;
 
+    /** @deprecated Use `getSetting("ActiveChatUserListTimeout")` instead */
     getActiveChatUserListTimeout(): number;
 
+    /** @deprecated Use `getSetting("WebServerPort")` instead */
     getWebSocketPort(): number;
-
+    /** @deprecated Use `getSetting("WebServerPort")` instead */
     getWebServerPort(): number;
 
+    /** @deprecated Use `getSetting("ViewerDB")` instead */
     getViewerDbStatus(): boolean;
 
+    /** @deprecated Use `getSetting("AutoUpdateLevel")` instead */
     getAutoUpdateLevel(): FirebotAutoUpdateLevel;
 
+    /** @deprecated Use `getSetting("AudioOutputDevice")` instead */
     getAudioOutputDevice(): FirebotAudioOutputDevice;
 
+    /** @deprecated Use `getSetting("DebugMode")` instead */
     debugModeEnabled(): boolean;
 
+    /** @deprecated Use `getSetting("WhileLoopEnabled")` instead */
     getWhileLoopEnabled(): boolean;
+    /** @deprecated Use `saveSetting("WhileLoopEnabled", value)` instead */
     setWhileLoopEnabled(enabled: boolean): void;
 
+    /** @deprecated Use `getSetting("SidebarControlledServices")` instead */
     getSidebarControlledServices(): string[];
 
+    /** @deprecated Use `getSetting("MinimizeToTray")` instead */
     getMinimizeToTray(): boolean;
+    /** @deprecated Use `saveSetting("MinimizeToTray", value)` instead */
     setMinimizeToTray(minimizeToTray: boolean): void;
 };


### PR DESCRIPTION
- Add tiny-typed-emitter dependency
- Bump deps to match Firebot v5.64-beta1:
  - @twurple/* from 7.0.6 to [7.2.1](<https://github.com/crowbartools/Firebot/blob/84b96799af4ab83833aee5e181a54490a425d993/package-lock.json#L3126>)
  - @types/angular from 1.8.1 to [1.8.4](<https://github.com/crowbartools/Firebot/blob/84b96799af4ab83833aee5e181a54490a425d993/package-lock.json#L3446>)
  - @types/express from 4.17.1 to [4.17.21](<https://github.com/crowbartools/Firebot/blob/84b96799af4ab83833aee5e181a54490a425d993/package-lock.json#L3489>) (mistyped in the commit message, plz forgive me)
  - @types/node from 18.18.2 to [20.17.12](<https://github.com/crowbartools/Firebot/blob/84b96799af4ab83833aee5e181a54490a425d993/package-lock.json#L3552>)
  - moment [remains unchanged](<https://github.com/crowbartools/Firebot/blob/84b96799af4ab83833aee5e181a54490a425d993/package-lock.json#L10853>)
- HttpServerManager improvements:
  - Add websocket enhancements from https://github.com/crowbartools/Firebot/commit/950077a2b5a4b45e966c36c4985552697e7ca032:
    - `registerCustomWebSocketListener`
    - `triggerCustomWebSocketEvent`
    - `unregisterCustomWebSocketListener`
  - Templatized `sendToOverlay`
  - Better `registerCustomRoute` callback typings
  - Better `startHttpService` typings
  - Add events:
    - "overlay-connected": `(instanceName?: string) => void`
    - "overlay-event": `(event: TUnknown) => void`
  - JSDoc (almost) everything
- FirebotSettings improvements from https://github.com/crowbartools/Firebot/pull/2936:
  - Add the plethora of associated events:
    - `settings:setting-updated:${setting-name}`
    - `settings:setting-deleted:${setting-name}`
  - Include *all* of the deprecation wrappers.