### PR TITLE
Properly support enum and multiselect settings in game manager

### DIFF
--- a/types/modules/game-manager.d.ts
+++ b/types/modules/game-manager.d.ts
@@ -3,6 +3,7 @@ type SettingType =
     | "number"
     | "boolean"
     | "enum"
+    | "multiselect"
     | "filepath"
     | "currency-select"
     | "chatter-select"
@@ -19,6 +20,14 @@ export type SettingDefinition = {
      */
     tip: string;
     default: any;
+    /**
+     * Options for the "enum" type.
+     */
+    options?: string[];
+    /**
+     * Settings for the "multiselect" type.
+     */
+    settings?: Record<string, any>;
     /**
      * A rank to tell the UI how to order settings.
      */


### PR DESCRIPTION
This PR properly supports the `enum` and `multiselect` settings in the Game Manager.

- **enum**: Added the `options` field for the list of strings for the "enum" type
- **multiselect**: Added this as a SettingType and also added `settings` field

This should all be backward compatible since the `options` and `settings` fields are optional.

I need this for a custom game I'm working on. With these settings I am able to have proper configuration for my game as shown here. I copy/pasted in some settings from the existing trivia game to demonstrate that this actually works...

![image](https://github.com/user-attachments/assets/4d44da48-09f4-4b95-8154-73328b35e50b)
