### PR TITLE
feat: pass scriptDataDir property to custom scripts

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -88,6 +88,7 @@ export type ScriptModules = {
     resourceTokenManager: ResourceTokenManager;
     request: unknown;
     restrictionManager: RestrictionManager;
+    scriptDataDir: string;
     spawn: typeof ChildProcess["spawn"];
     twitchApi: TwitchApi;
     twitchChat: TwitchChat;


### PR DESCRIPTION
## Description

Adds the `scriptDataDir` that was added in https://github.com/crowbartools/Firebot/commit/97e17ed0b1a93abd3c6610f176d12f4123fb7ba6

## Motivation

https://github.com/crowbartools/Firebot/issues/3180

## Testing

I confirmed that this works in the application for which I originally requested the feature. It resolved to `/home/REDACTED/.config/Firebot/v5/profiles/Main Profile/script-data/mage-trivia-game` as shown in log output.